### PR TITLE
Task improvements

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -119,8 +119,8 @@ For source formatting, add the `spring-javaformat-gradle-plugin` to your `build`
 	apply plugin: 'io.spring.javaformat'
 ----
 
-The plugin adds `format` and `formatcheck` tasks to your project.
-The `formatcheck` task is automatically applied when running the standard gradle `check` task.
+The plugin adds `format` and `checkFormat` tasks to your project.
+The `checkFormat` task is automatically applied when running the standard Gradle `check` task.
 
 #### Checkstyle
 To enforce checksyle conventions add the checkstyle plugin and include a dependency on `spring-javaformat-checkstyle`:

--- a/spring-javaformat-gradle/spring-javaformat-gradle-plugin/src/main/java/io/spring/javaformat/gradle/CheckTask.java
+++ b/spring-javaformat-gradle/spring-javaformat-gradle-plugin/src/main/java/io/spring/javaformat/gradle/CheckTask.java
@@ -35,12 +35,12 @@ public class CheckTask extends FormatterTask {
 	/**
 	 * The name of the task.
 	 */
-	public static final String NAME = "formatcheck";
+	public static final String NAME = "checkFormat";
 
 	/**
 	 * The description of the task.
 	 */
-	public static final String DESCRIPTION = "Run spring java formatting checks";
+	public static final String DESCRIPTION = "Run Spring Java formatting checks";
 
 	@TaskAction
 	public void checkFormatting() throws IOException, InterruptedException {

--- a/spring-javaformat-gradle/spring-javaformat-gradle-plugin/src/main/java/io/spring/javaformat/gradle/FormatTask.java
+++ b/spring-javaformat-gradle/spring-javaformat-gradle-plugin/src/main/java/io/spring/javaformat/gradle/FormatTask.java
@@ -38,7 +38,7 @@ public class FormatTask extends FormatterTask {
 	/**
 	 * The description of the task.
 	 */
-	public static final String DESCRIPTION = "Apply spring java formatting";
+	public static final String DESCRIPTION = "Apply Spring Java formatting";
 
 	@TaskAction
 	public void format() throws IOException, InterruptedException {

--- a/spring-javaformat-gradle/spring-javaformat-gradle-plugin/src/main/java/io/spring/javaformat/gradle/SpringJavaFormatPlugin.java
+++ b/spring-javaformat-gradle/spring-javaformat-gradle-plugin/src/main/java/io/spring/javaformat/gradle/SpringJavaFormatPlugin.java
@@ -42,17 +42,20 @@ public class SpringJavaFormatPlugin implements Plugin<Project> {
 		this.project.getPlugins().withType(JavaBasePlugin.class, (plugin) -> {
 			Task formatAll = this.project.task(FormatTask.NAME);
 			formatAll.setDescription(FormatTask.DESCRIPTION);
+			Task checkAll = this.project.task(CheckTask.NAME);
+			checkAll.setDescription(CheckTask.DESCRIPTION);
+			this.project.getTasks().getByName(JavaBasePlugin.CHECK_TASK_NAME)
+					.dependsOn(checkAll);
 			this.project.getConvention().getPlugin(JavaPluginConvention.class)
 					.getSourceSets()
-					.all((sourceSet) -> addSourceTasks(sourceSet, formatAll));
+					.all((sourceSet) -> addSourceTasks(sourceSet, checkAll, formatAll));
 		});
 	}
 
-	private void addSourceTasks(SourceSet sourceSet, Task formatAll) {
+	private void addSourceTasks(SourceSet sourceSet, Task checkAll, Task formatAll) {
 		CheckTask checkTask = addSourceTask(sourceSet, CheckTask.class, CheckTask.NAME,
 				CheckTask.DESCRIPTION);
-		this.project.getTasks().getByName(JavaBasePlugin.CHECK_TASK_NAME)
-				.dependsOn(checkTask);
+		checkAll.dependsOn(checkTask);
 		FormatTask formatSourceSet = addSourceTask(sourceSet, FormatTask.class,
 				FormatTask.NAME, FormatTask.DESCRIPTION);
 		formatSourceSet.conventionMapping("encoding", () -> "UTF-8");

--- a/spring-javaformat-gradle/spring-javaformat-gradle-plugin/src/test/java/io/spring/javaformat/gradle/CheckTaskTests.java
+++ b/spring-javaformat-gradle/spring-javaformat-gradle-plugin/src/test/java/io/spring/javaformat/gradle/CheckTaskTests.java
@@ -40,7 +40,7 @@ public class CheckTaskTests {
 	public void checkOk() throws IOException {
 		BuildResult result = this.gradleBuild.source("src/test/resources/check-ok")
 				.build("check");
-		assertThat(result.task(":formatcheckMain").getOutcome())
+		assertThat(result.task(":checkFormatMain").getOutcome())
 				.isEqualTo(TaskOutcome.SUCCESS);
 	}
 
@@ -48,7 +48,7 @@ public class CheckTaskTests {
 	public void checkBad() throws IOException {
 		BuildResult result = this.gradleBuild.source("src/test/resources/check-bad")
 				.buildAndFail("check");
-		assertThat(result.task(":formatcheckMain").getOutcome())
+		assertThat(result.task(":checkFormatMain").getOutcome())
 				.isEqualTo(TaskOutcome.FAILED);
 	}
 


### PR DESCRIPTION
Hopefully the commit message for https://github.com/spring-io/spring-javaformat/commit/b75ea823685c20657ca5b5e6111aff1973f913a1 explains the rationale for those changes.

When I was working on them I noticed that there was no task for running all of the formatting checks (analogous to `cleanEclipse`) so the second commit adds one named `checkFormat`. This means that a typical Java project will now have the following tasks:

- `check`
- `checkFormat`
- `checkFormatMain`
- `checkFormatTest`

This seems to fit nicely with the pattern of appending something to the name of the task as it gets more specific.