### PR TITLE
Fix plugin prefix

### DIFF
--- a/spring-javaformat-intellij/spring-javaformat-intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/spring-javaformat-intellij/spring-javaformat-intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -2,7 +2,7 @@
 	<id>spring-javaformat</id>
 	<name>spring-javaformat</name>
 	<version>1.0</version>
-	<vendor url="https://github.com/spring-io/spring-format">Spring</vendor>
+	<vendor url="https://github.com/spring-io/spring-javaformat">Spring</vendor>
 	<description><![CDATA[Code formatter for Spring.]]></description>
 	<idea-version since-build="162.0"/>
 	<depends>org.jetbrains.idea.maven</depends>

--- a/spring-javaformat-maven/spring-javaformat-maven-plugin/src/main/java/io/spring/format/maven/FormatMojo.java
+++ b/spring-javaformat-maven/spring-javaformat-maven-plugin/src/main/java/io/spring/format/maven/FormatMojo.java
@@ -63,13 +63,13 @@ public abstract class FormatMojo extends AbstractMojo {
 	/**
 	 * Specifies the names filter of the source files to be excluded.
 	 */
-	@Parameter(property = "spring-format.excludes")
+	@Parameter(property = "spring-javaformat.excludes")
 	private String[] excludes;
 
 	/**
 	 * Specifies the names filter of the source files to be included.
 	 */
-	@Parameter(property = "spring-format.includes")
+	@Parameter(property = "spring-javaformat.includes")
 	private String[] includes;
 
 	/**

--- a/spring-javaformat-maven/spring-javaformat-maven-plugin/src/main/java/io/spring/format/maven/ValidateMojo.java
+++ b/spring-javaformat-maven/spring-javaformat-maven-plugin/src/main/java/io/spring/format/maven/ValidateMojo.java
@@ -47,7 +47,7 @@ public class ValidateMojo extends FormatMojo {
 			StringBuilder message = new StringBuilder(
 					"Formatting violations found in the following files:\n");
 			problems.stream().forEach((f) -> message.append(" * " + f + "\n"));
-			message.append("\nRun `spring-format:apply` to fix.");
+			message.append("\nRun `spring-javaformat:apply` to fix.");
 			throw new MojoFailureException(message.toString());
 		}
 	}


### PR DESCRIPTION
It looks like this project was initially named `spring-format`. I've found a few places where the previous prefix wasn't renamed.