### PR TITLE
Add skip property to Maven plugin

### DIFF
--- a/spring-javaformat-maven/spring-javaformat-maven-plugin/src/it/validate-skip/pom.xml
+++ b/spring-javaformat-maven/spring-javaformat-maven-plugin/src/it/validate-skip/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>io.spring.javaformat</groupId>
+	<artifactId>validate-skip</artifactId>
+	<version>0.0.1.BUILD-SNAPSHOT</version>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>@project.groupId@</groupId>
+				<artifactId>@project.artifactId@</artifactId>
+				<version>@project.version@</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>validate</goal>
+						</goals>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/spring-javaformat-maven/spring-javaformat-maven-plugin/src/it/validate-skip/src/main/java/simple/Simple.java
+++ b/spring-javaformat-maven/spring-javaformat-maven-plugin/src/it/validate-skip/src/main/java/simple/Simple.java
@@ -1,0 +1,15 @@
+package simple;
+
+/**
+ * Simple.
+ *
+ * @author Phillip Webb
+ * @since 1.0.0
+ */
+public class Simple  {
+
+	public static void main(String[] args) throws Exception {
+		// Main method
+	}
+
+}

--- a/spring-javaformat-maven/spring-javaformat-maven-plugin/src/main/java/io/spring/format/maven/ValidateMojo.java
+++ b/spring-javaformat-maven/spring-javaformat-maven-plugin/src/main/java/io/spring/format/maven/ValidateMojo.java
@@ -27,6 +27,7 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 
 /**
  * Validates that source formatting matches the required style.
@@ -36,9 +37,19 @@ import org.apache.maven.plugins.annotations.Mojo;
 @Mojo(name = "validate", defaultPhase = LifecyclePhase.VALIDATE)
 public class ValidateMojo extends FormatMojo {
 
+	/**
+	 * Skip the execution.
+	 */
+	@Parameter(property = "spring-javaformat.skip", defaultValue = "false")
+	private boolean skip;
+
 	@Override
 	protected void execute(List<File> files, Charset encoding)
 			throws MojoExecutionException, MojoFailureException {
+		if (this.skip) {
+			getLog().debug("skipping validation as per configuration.");
+			return;
+		}
 		FileFormatter formatter = new FileFormatter();
 		List<File> problems = formatter.formatFiles(files, encoding)
 				.filter(FileEdit::hasEdits).map(FileEdit::getFile)


### PR DESCRIPTION
This commit adds a convenient and usual "skip" property to disable the
execution of the validate goal.