### PR TITLE
Consider adding import order check

### DIFF
--- a/spring-javaformat-eclipse/io.spring.javaformat.eclipse/src/io/spring/javaformat/eclipse/Activator.java
+++ b/spring-javaformat-eclipse/io.spring.javaformat.eclipse/src/io/spring/javaformat/eclipse/Activator.java
@@ -16,9 +16,10 @@
 
 package io.spring.javaformat.eclipse;
 
-import io.spring.javaformat.eclipse.gradle.RefreshProjectSettingsListeners;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
+
+import io.spring.javaformat.eclipse.gradle.RefreshProjectSettingsListeners;
 
 /**
  * The activator class controls the plug-in life cycle.

--- a/spring-javaformat-eclipse/io.spring.javaformat.eclipse/src/io/spring/javaformat/eclipse/formatter/SpringCodeFormatter.java
+++ b/spring-javaformat-eclipse/io.spring.javaformat.eclipse/src/io/spring/javaformat/eclipse/formatter/SpringCodeFormatter.java
@@ -18,10 +18,11 @@ package io.spring.javaformat.eclipse.formatter;
 
 import java.util.Map;
 
-import io.spring.javaformat.formatter.Formatter;
 import org.eclipse.jdt.core.formatter.CodeFormatter;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.text.edits.TextEdit;
+
+import io.spring.javaformat.formatter.Formatter;
 
 /**
  * Eclipse {@link CodeFormatter} for Spring formatting.

--- a/spring-javaformat-eclipse/io.spring.javaformat.eclipse/src/io/spring/javaformat/eclipse/gradle/RefreshProjectsSettingsJob.java
+++ b/spring-javaformat-eclipse/io.spring.javaformat.eclipse/src/io/spring/javaformat/eclipse/gradle/RefreshProjectsSettingsJob.java
@@ -25,9 +25,6 @@ import com.google.common.base.Optional;
 import com.gradleware.tooling.toolingmodel.OmniEclipseProject;
 import com.gradleware.tooling.toolingmodel.OmniProjectTask;
 import com.gradleware.tooling.toolingmodel.repository.FetchStrategy;
-import io.spring.javaformat.eclipse.Executor;
-import io.spring.javaformat.eclipse.Messages;
-import io.spring.javaformat.eclipse.projectsettings.ProjectSettingsFilesLocator;
 import org.eclipse.buildship.core.CorePlugin;
 import org.eclipse.buildship.core.workspace.GradleBuild;
 import org.eclipse.buildship.core.workspace.GradleWorkspaceManager;
@@ -40,6 +37,10 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.gradle.tooling.CancellationTokenSource;
 import org.gradle.tooling.GradleConnector;
+
+import io.spring.javaformat.eclipse.Executor;
+import io.spring.javaformat.eclipse.Messages;
+import io.spring.javaformat.eclipse.projectsettings.ProjectSettingsFilesLocator;
 
 /**
  * Job to trigger refresh of project specific settings when the gradle plugin is used.

--- a/spring-javaformat-eclipse/io.spring.javaformat.eclipse/src/io/spring/javaformat/eclipse/m2e/ProjectSettingsConfigurator.java
+++ b/spring-javaformat-eclipse/io.spring.javaformat.eclipse/src/io/spring/javaformat/eclipse/m2e/ProjectSettingsConfigurator.java
@@ -20,15 +20,16 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import io.spring.javaformat.eclipse.Executor;
-import io.spring.javaformat.eclipse.Messages;
-import io.spring.javaformat.eclipse.projectsettings.ProjectSettingsFiles;
-import io.spring.javaformat.eclipse.projectsettings.ProjectSettingsFilesLocator;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.m2e.core.project.configurator.AbstractProjectConfigurator;
 import org.eclipse.m2e.core.project.configurator.ProjectConfigurationRequest;
+
+import io.spring.javaformat.eclipse.Executor;
+import io.spring.javaformat.eclipse.Messages;
+import io.spring.javaformat.eclipse.projectsettings.ProjectSettingsFiles;
+import io.spring.javaformat.eclipse.projectsettings.ProjectSettingsFilesLocator;
 
 /**
  * Configurator to apply project specific settings.

--- a/spring-javaformat-gradle/spring-javaformat-gradle-plugin/src/main/java/io/spring/javaformat/gradle/CheckTask.java
+++ b/spring-javaformat-gradle/spring-javaformat-gradle-plugin/src/main/java/io/spring/javaformat/gradle/CheckTask.java
@@ -21,9 +21,10 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import io.spring.javaformat.formatter.FileEdit;
 import org.gradle.api.GradleException;
 import org.gradle.api.tasks.TaskAction;
+
+import io.spring.javaformat.formatter.FileEdit;
 
 /**
  * {@link FormatterTask} to check formatting.

--- a/spring-javaformat-gradle/spring-javaformat-gradle-plugin/src/main/java/io/spring/javaformat/gradle/FormatTask.java
+++ b/spring-javaformat-gradle/spring-javaformat-gradle-plugin/src/main/java/io/spring/javaformat/gradle/FormatTask.java
@@ -18,10 +18,11 @@ package io.spring.javaformat.gradle;
 
 import java.io.IOException;
 
-import io.spring.javaformat.formatter.FileEdit;
-import io.spring.javaformat.formatter.FileFormatterException;
 import org.gradle.api.GradleException;
 import org.gradle.api.tasks.TaskAction;
+
+import io.spring.javaformat.formatter.FileEdit;
+import io.spring.javaformat.formatter.FileFormatterException;
 
 /**
  * {@link FormatterTask} to apply formatting.

--- a/spring-javaformat-gradle/spring-javaformat-gradle-plugin/src/main/java/io/spring/javaformat/gradle/FormatterTask.java
+++ b/spring-javaformat-gradle/spring-javaformat-gradle-plugin/src/main/java/io/spring/javaformat/gradle/FormatterTask.java
@@ -19,11 +19,12 @@ package io.spring.javaformat.gradle;
 import java.nio.charset.Charset;
 import java.util.stream.Stream;
 
-import io.spring.javaformat.formatter.FileEdit;
-import io.spring.javaformat.formatter.FileFormatter;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.SourceTask;
+
+import io.spring.javaformat.formatter.FileEdit;
+import io.spring.javaformat.formatter.FileFormatter;
 
 /**
  * Abstract base class for formatter tasks.

--- a/spring-javaformat-gradle/spring-javaformat-gradle-plugin/src/test/java/io/spring/javaformat/gradle/CheckTaskTests.java
+++ b/spring-javaformat-gradle/spring-javaformat-gradle-plugin/src/test/java/io/spring/javaformat/gradle/CheckTaskTests.java
@@ -18,11 +18,12 @@ package io.spring.javaformat.gradle;
 
 import java.io.IOException;
 
-import io.spring.javaformat.gradle.testkit.GradleBuild;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.TaskOutcome;
 import org.junit.Rule;
 import org.junit.Test;
+
+import io.spring.javaformat.gradle.testkit.GradleBuild;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/spring-javaformat-gradle/spring-javaformat-gradle-plugin/src/test/java/io/spring/javaformat/gradle/FormatTaskTests.java
+++ b/spring-javaformat-gradle/spring-javaformat-gradle-plugin/src/test/java/io/spring/javaformat/gradle/FormatTaskTests.java
@@ -20,11 +20,12 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 
-import io.spring.javaformat.gradle.testkit.GradleBuild;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.TaskOutcome;
 import org.junit.Rule;
 import org.junit.Test;
+
+import io.spring.javaformat.gradle.testkit.GradleBuild;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/spring-javaformat-gradle/spring-javaformat-gradle-plugin/src/test/java/io/spring/javaformat/gradle/testkit/GradleBuild.java
+++ b/spring-javaformat-gradle/spring-javaformat-gradle-plugin/src/test/java/io/spring/javaformat/gradle/testkit/GradleBuild.java
@@ -31,8 +31,6 @@ import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathFactory;
 
-import io.spring.javaformat.formatter.Formatter;
-import io.spring.javaformat.formatter.eclipse.Preparator;
 import org.eclipse.jdt.core.formatter.CodeFormatter;
 import org.gradle.internal.impldep.com.google.common.base.Charsets;
 import org.gradle.testkit.runner.BuildResult;
@@ -42,6 +40,9 @@ import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import org.xml.sax.InputSource;
+
+import io.spring.javaformat.formatter.Formatter;
+import io.spring.javaformat.formatter.eclipse.Preparator;
 
 /**
  * A {@link TestRule} for running a Gradle build using {@link GradleRunner}.

--- a/spring-javaformat-intellij/spring-javaformat-intellij-plugin/src/main/java/io/spring/format/formatter/intellij/SpringFormatComponent.java
+++ b/spring-javaformat-intellij/spring-javaformat-intellij-plugin/src/main/java/io/spring/format/formatter/intellij/SpringFormatComponent.java
@@ -27,13 +27,14 @@ import com.intellij.openapi.components.ProjectComponent;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.codeStyle.CodeStyleManager;
+import org.picocontainer.MutablePicoContainer;
+
 import io.spring.format.formatter.intellij.codestyle.SpringCodeStyleManager;
 import io.spring.format.formatter.intellij.codestyle.monitor.FileMonitor;
 import io.spring.format.formatter.intellij.codestyle.monitor.GradleMonitor;
 import io.spring.format.formatter.intellij.codestyle.monitor.MavenMonitor;
 import io.spring.format.formatter.intellij.codestyle.monitor.Monitors;
 import io.spring.format.formatter.intellij.codestyle.monitor.Trigger.State;
-import org.picocontainer.MutablePicoContainer;
 
 /**
  * {@link ProjectComponent} to add Spring Java Format IntelliJ support.

--- a/spring-javaformat-intellij/spring-javaformat-intellij-plugin/src/main/java/io/spring/format/formatter/intellij/StatusIndicator.java
+++ b/spring-javaformat-intellij/spring-javaformat-intellij-plugin/src/main/java/io/spring/format/formatter/intellij/StatusIndicator.java
@@ -29,6 +29,7 @@ import com.intellij.openapi.wm.StatusBarWidget;
 import com.intellij.openapi.wm.WindowManager;
 import com.intellij.openapi.wm.WindowManagerListener;
 import com.intellij.util.Consumer;
+
 import io.spring.format.formatter.intellij.codestyle.monitor.Trigger.State;
 
 /**

--- a/spring-javaformat-intellij/spring-javaformat-intellij-plugin/src/main/java/io/spring/format/formatter/intellij/codestyle/SpringReformatter.java
+++ b/spring-javaformat-intellij/spring-javaformat-intellij-plugin/src/main/java/io/spring/format/formatter/intellij/codestyle/SpringReformatter.java
@@ -33,9 +33,10 @@ import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.util.IncorrectOperationException;
-import io.spring.javaformat.formatter.Formatter;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.text.edits.TextEdit;
+
+import io.spring.javaformat.formatter.Formatter;
 
 /**
  * Reformatter used by {@link SpringCodeStyleManager} to determine when formatting can

--- a/spring-javaformat-intellij/spring-javaformat-intellij-plugin/src/main/java/io/spring/format/formatter/intellij/codestyle/monitor/FileMonitor.java
+++ b/spring-javaformat-intellij/spring-javaformat-intellij-plugin/src/main/java/io/spring/format/formatter/intellij/codestyle/monitor/FileMonitor.java
@@ -23,6 +23,7 @@ import com.intellij.openapi.vfs.VirtualFileListener;
 import com.intellij.openapi.vfs.VirtualFileManager;
 import com.intellij.openapi.vfs.VirtualFileMoveEvent;
 import com.intellij.openapi.vfs.VirtualFilePropertyEvent;
+
 import io.spring.format.formatter.intellij.codestyle.monitor.Trigger.State;
 
 /**

--- a/spring-javaformat-intellij/spring-javaformat-intellij-plugin/src/main/java/io/spring/format/formatter/intellij/codestyle/monitor/GradleMonitor.java
+++ b/spring-javaformat-intellij/spring-javaformat-intellij-plugin/src/main/java/io/spring/format/formatter/intellij/codestyle/monitor/GradleMonitor.java
@@ -26,8 +26,9 @@ import com.intellij.openapi.externalSystem.service.project.ProjectDataManager;
 import com.intellij.openapi.externalSystem.service.project.manage.ProjectDataImportListener;
 import com.intellij.openapi.project.Project;
 import com.intellij.util.messages.MessageBusConnection;
-import io.spring.format.formatter.intellij.codestyle.monitor.Trigger.State;
 import org.jetbrains.plugins.gradle.util.GradleConstants;
+
+import io.spring.format.formatter.intellij.codestyle.monitor.Trigger.State;
 
 /**
  * {@link Monitor} that looks for a {@code spring-javaformat-gradle-plugin} declaration in

--- a/spring-javaformat-intellij/spring-javaformat-intellij-plugin/src/main/java/io/spring/format/formatter/intellij/codestyle/monitor/MavenMonitor.java
+++ b/spring-javaformat-intellij/spring-javaformat-intellij-plugin/src/main/java/io/spring/format/formatter/intellij/codestyle/monitor/MavenMonitor.java
@@ -20,12 +20,13 @@ import java.util.List;
 
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Pair;
-import io.spring.format.formatter.intellij.codestyle.monitor.Trigger.State;
 import org.jetbrains.idea.maven.project.MavenProject;
 import org.jetbrains.idea.maven.project.MavenProjectChanges;
 import org.jetbrains.idea.maven.project.MavenProjectsManager;
 import org.jetbrains.idea.maven.project.MavenProjectsTree.Listener;
 import org.jetbrains.idea.maven.server.NativeMavenProjectHolder;
+
+import io.spring.format.formatter.intellij.codestyle.monitor.Trigger.State;
 
 /**
  * {@link Monitor} that looks for a {@code spring-javaformat-maven-plugin} declaration in

--- a/spring-javaformat-intellij/spring-javaformat-intellij-plugin/src/main/java/io/spring/format/formatter/intellij/codestyle/monitor/Monitors.java
+++ b/spring-javaformat-intellij/spring-javaformat-intellij-plugin/src/main/java/io/spring/format/formatter/intellij/codestyle/monitor/Monitors.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import com.intellij.openapi.project.Project;
+
 import io.spring.format.formatter.intellij.codestyle.monitor.Trigger.State;
 
 /**

--- a/spring-javaformat-maven/spring-javaformat-maven-plugin/src/main/java/io/spring/format/maven/ApplyMojo.java
+++ b/spring-javaformat-maven/spring-javaformat-maven-plugin/src/main/java/io/spring/format/maven/ApplyMojo.java
@@ -20,13 +20,14 @@ import java.io.File;
 import java.nio.charset.Charset;
 import java.util.List;
 
-import io.spring.javaformat.formatter.FileEdit;
-import io.spring.javaformat.formatter.FileFormatter;
-import io.spring.javaformat.formatter.FileFormatterException;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
+
+import io.spring.javaformat.formatter.FileEdit;
+import io.spring.javaformat.formatter.FileFormatter;
+import io.spring.javaformat.formatter.FileFormatterException;
 
 /**
  * Applies source formatting to the codebase.

--- a/spring-javaformat-maven/spring-javaformat-maven-plugin/src/main/java/io/spring/format/maven/ValidateMojo.java
+++ b/spring-javaformat-maven/spring-javaformat-maven-plugin/src/main/java/io/spring/format/maven/ValidateMojo.java
@@ -21,13 +21,14 @@ import java.nio.charset.Charset;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import io.spring.javaformat.formatter.FileEdit;
-import io.spring.javaformat.formatter.FileFormatter;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+
+import io.spring.javaformat.formatter.FileEdit;
+import io.spring.javaformat.formatter.FileFormatter;
 
 /**
  * Validates that source formatting matches the required style.

--- a/spring-javaformat/spring-javaformat-checkstyle/src/main/java/io/spring/javaformat/checkstyle/SpringChecks.java
+++ b/spring-javaformat/spring-javaformat-checkstyle/src/main/java/io/spring/javaformat/checkstyle/SpringChecks.java
@@ -36,6 +36,7 @@ import com.puppycrawl.tools.checkstyle.api.FileSetCheck;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
 import com.puppycrawl.tools.checkstyle.filters.SuppressElement;
+
 import io.spring.javaformat.checkstyle.check.SpringHeaderCheck;
 
 /**

--- a/spring-javaformat/spring-javaformat-checkstyle/src/main/java/io/spring/javaformat/checkstyle/check/SpringImportOrderCheck.java
+++ b/spring-javaformat/spring-javaformat-checkstyle/src/main/java/io/spring/javaformat/checkstyle/check/SpringImportOrderCheck.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.javaformat.checkstyle.check;
+
+import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
+
+/**
+ * Checks that the order of imports follow Spring conventions.
+ *
+ * @author Vedran Pavic
+ */
+public class SpringImportOrderCheck extends ImportOrderCheck {
+
+	private static final String DEFAULT_PROJECT_ROOT_PACKAGE = "org.springframework";
+
+	public SpringImportOrderCheck() {
+		setProjectRootPackage(DEFAULT_PROJECT_ROOT_PACKAGE);
+		setOrdered(true);
+		setSeparated(true);
+		setOption("bottom");
+		setSortStaticImportsAlphabetically(true);
+	}
+
+	public void setProjectRootPackage(String rootProjectPackage) {
+		setGroups("java", "/^javax?\\./", "*", rootProjectPackage);
+	}
+
+}

--- a/spring-javaformat/spring-javaformat-checkstyle/src/main/resources/io/spring/javaformat/checkstyle/spring-checkstyle.xml
+++ b/spring-javaformat/spring-javaformat-checkstyle/src/main/resources/io/spring/javaformat/checkstyle/spring-checkstyle.xml
@@ -78,13 +78,7 @@
 		<module name="com.puppycrawl.tools.checkstyle.checks.imports.UnusedImportsCheck">
 			<property name="processJavadoc" value="true" />
 		</module>
-		<module name="com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck">
-			<property name="groups" value="java,/^javax?\./,*,org.springframework" />
-			<property name="ordered" value="true" />
-			<property name="separated" value="true" />
-			<property name="option" value="bottom" />
-			<property name="sortStaticImportsAlphabetically" value="true" />
-		</module>
+		<module name="io.spring.javaformat.checkstyle.check.SpringImportOrderCheck"/>
 
 		<!-- Javadoc Comments -->
 		<module name="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck">

--- a/spring-javaformat/spring-javaformat-checkstyle/src/test/java/io/spring/javaformat/checkstyle/SpringConfigurationLoaderTests.java
+++ b/spring-javaformat/spring-javaformat-checkstyle/src/test/java/io/spring/javaformat/checkstyle/SpringConfigurationLoaderTests.java
@@ -25,8 +25,9 @@ import com.puppycrawl.tools.checkstyle.PackageObjectFactory;
 import com.puppycrawl.tools.checkstyle.PropertiesExpander;
 import com.puppycrawl.tools.checkstyle.PropertyResolver;
 import com.puppycrawl.tools.checkstyle.api.FileSetCheck;
-import io.spring.javaformat.checkstyle.check.SpringHeaderCheck;
 import org.junit.Test;
+
+import io.spring.javaformat.checkstyle.check.SpringHeaderCheck;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/spring-javaformat/spring-javaformat-formatter/src/main/java/io/spring/javaformat/formatter/Formatter.java
+++ b/spring-javaformat/spring-javaformat-formatter/src/main/java/io/spring/javaformat/formatter/Formatter.java
@@ -26,12 +26,13 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.function.Supplier;
 
-import io.spring.javaformat.formatter.eclipse.ExtendedCodeFormatter;
-import io.spring.javaformat.formatter.eclipse.Preparator;
-import io.spring.javaformat.formatter.preparator.Preparators;
 import org.eclipse.jdt.core.formatter.CodeFormatter;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.text.edits.TextEdit;
+
+import io.spring.javaformat.formatter.eclipse.ExtendedCodeFormatter;
+import io.spring.javaformat.formatter.eclipse.Preparator;
+import io.spring.javaformat.formatter.preparator.Preparators;
 
 /**
  * A {@link CodeFormatter} that applies Spring formatting conventions.

--- a/spring-javaformat/spring-javaformat-formatter/src/main/java/io/spring/javaformat/formatter/preparator/CodeLineBreakPreparator.java
+++ b/spring-javaformat/spring-javaformat-formatter/src/main/java/io/spring/javaformat/formatter/preparator/CodeLineBreakPreparator.java
@@ -16,9 +16,6 @@
 
 package io.spring.javaformat.formatter.preparator;
 
-import io.spring.javaformat.formatter.eclipse.Preparator;
-import io.spring.javaformat.formatter.eclipse.Token;
-import io.spring.javaformat.formatter.eclipse.TokenManager;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.AbstractTypeDeclaration;
@@ -29,6 +26,10 @@ import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.formatter.CodeFormatter;
 import org.eclipse.jdt.internal.compiler.parser.TerminalTokens;
+
+import io.spring.javaformat.formatter.eclipse.Preparator;
+import io.spring.javaformat.formatter.eclipse.Token;
+import io.spring.javaformat.formatter.eclipse.TokenManager;
 
 /**
  * {@link Preparator} to fine tune curly-brace line breaks.

--- a/spring-javaformat/spring-javaformat-formatter/src/main/java/io/spring/javaformat/formatter/preparator/JavadocLineBreakPreparator.java
+++ b/spring-javaformat/spring-javaformat-formatter/src/main/java/io/spring/javaformat/formatter/preparator/JavadocLineBreakPreparator.java
@@ -20,9 +20,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import io.spring.javaformat.formatter.eclipse.Preparator;
-import io.spring.javaformat.formatter.eclipse.Token;
-import io.spring.javaformat.formatter.eclipse.TokenManager;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.Comment;
@@ -33,6 +30,10 @@ import org.eclipse.jdt.core.dom.TextElement;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.formatter.CodeFormatter;
 import org.eclipse.jdt.internal.compiler.parser.TerminalTokens;
+
+import io.spring.javaformat.formatter.eclipse.Preparator;
+import io.spring.javaformat.formatter.eclipse.Token;
+import io.spring.javaformat.formatter.eclipse.TokenManager;
 
 /**
  * {@link Preparator} to fine tune Javadoc whitespace.

--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -78,7 +78,7 @@
 			<property name="processJavadoc" value="true" />
 		</module>
 		<module name="com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck">
-			<property name="groups" value="java,/^javax?\./,*,org.springframework" />
+			<property name="groups" value="java,/^javax?\./,*,io.spring" />
 			<property name="ordered" value="true" />
 			<property name="separated" value="true" />
 			<property name="option" value="bottom" />


### PR DESCRIPTION
Checkstyle convention provided by this plugin enforces `ImportOrderCheck` with `groups` property set to `java,/^javax?\./,*,org.springframework`. While this is appropriate for projects from `spring-projects` organization, I believe that the projects from other Spring organizations (like parent org of this project, `spring-io`, or `spring-gradle-plugins`) should be able to use their root package (e.g. `io.spring`) as the last group.

I'm proposing addition of `SpringImportOrderCheck` which would apply most of what's currently configured with `ImportOrderCheck` but also allow to configure project's root package to set the last group of imports. This would also make the project generally much more attractive to broader audience IMO.

This PR is by no means complete, as it only touches the Checkstyle part, and doesn't do anything with formatter since I didn't want to go that deep without know if this proposal is acceptable.