### PR TITLE
Remove useless Maven prerequisites section

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,9 +50,6 @@
 		<tycho.version>1.1.0</tycho.version>
 		<tycho-extras.version>1.1.0</tycho-extras.version>
 	</properties>
-	<prerequisites>
-		<maven>3.5</maven>
-	</prerequisites>
 	<build>
 		<pluginManagement>
 			<plugins>
@@ -115,6 +112,26 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-eclipse-plugin</artifactId>
 					<version>2.10</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-enforcer-plugin</artifactId>
+					<version>3.0.0-M2</version>
+					<executions>
+						<execution>
+							<id>enforce-maven-version</id>
+							<goals>
+								<goal>enforce</goal>
+							</goals>
+							<configuration>
+								<rules>
+									<requireMavenVersion>
+										<version>3.5</version>
+									</requireMavenVersion>
+								</rules>
+							</configuration>
+						</execution>
+					</executions>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -460,6 +477,10 @@
 						</goals>
 					</execution>
 				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
Use maven-enforcer-plugin to enforce Maven version instead of prerequisites which generates a warning like this
`[WARNING] The project io.spring.javaformat:spring-javaformat-build:pom:0.0.7-SNAPSHOT uses prerequisites which is only intended for maven-plugin projects but not for non maven-plugin projects. For such purposes you should use the maven-enforcer-plugin. See https://maven.apache.org/enforcer/enforcer-rules/requireMavenVersion.html`