### PR TITLE
Update Checkstyle version in the README to match the version used in the build

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,5 @@
 :release-version: 0.0.14
-:checkstyle-version: 8.18
+:checkstyle-version: 8.21
 == Spring Java Format
 
 === What is this?


### PR DESCRIPTION
The `com.puppycrawl.tools:checkstyle` dependency version has been upgraded from 8.18 to 8.21 in `spring-javaformat-checkstyle` plugin internally but the version in the `maven-checkstyle-plugin` configuration hasn't been in the README.