### PR TITLE
Check that @TestTemplate methods are not public or private

### DIFF
--- a/spring-javaformat/spring-javaformat-checkstyle/src/main/java/io/spring/javaformat/checkstyle/check/SpringJUnit5Check.java
+++ b/spring-javaformat/spring-javaformat-checkstyle/src/main/java/io/spring/javaformat/checkstyle/check/SpringJUnit5Check.java
@@ -40,8 +40,11 @@ public class SpringJUnit5Check extends AbstractSpringCheck {
 
 	private static final String JUNIT5_TEST_ANNOTATION = "org.junit.jupiter.api.Test";
 
+	private static final String JUNIT5_TEST_TEMPLATE_ANNOTATION = "org.junit.jupiter.api.TestTemplate";
+
 	private static final List<String> TEST_ANNOTATIONS = Collections
-			.unmodifiableList(Arrays.asList("Test", JUNIT4_TEST_ANNOTATION, JUNIT5_TEST_ANNOTATION));
+			.unmodifiableList(Arrays.asList("Test", "TestTemplate", JUNIT4_TEST_ANNOTATION, JUNIT5_TEST_ANNOTATION,
+					JUNIT5_TEST_TEMPLATE_ANNOTATION));
 
 	private static final List<String> LIFECYCLE_ANNOTATIONS = Collections.unmodifiableList(Arrays.asList("BeforeAll",
 			"org.junit.jupiter.api.BeforeAll", "BeforeEach", "org.junit.jupiter.api.BeforeEach", "AfterAll",

--- a/spring-javaformat/spring-javaformat-checkstyle/src/test/resources/check/JUnit5BadModifier.txt
+++ b/spring-javaformat/spring-javaformat-checkstyle/src/test/resources/check/JUnit5BadModifier.txt
@@ -1,5 +1,7 @@
 +Test method 'doSomethingWorks' should not be public
 +Test method 'doSomethingElseWorks' should not be private
++Test method 'doSomethingWithTemplateWorks' should not be public
++Test method 'doSomethingElseWithTemplateWorks' should not be private
 +Lifecycle method 'publicBeforeAll' should not be public
 +Lifecycle method 'publicBeforeEach' should not be public
 +Lifecycle method 'publicAfterAll' should not be public

--- a/spring-javaformat/spring-javaformat-checkstyle/src/test/resources/source/JUnit5BadModifier.java
+++ b/spring-javaformat/spring-javaformat-checkstyle/src/test/resources/source/JUnit5BadModifier.java
@@ -73,4 +73,14 @@ public class JUnit5BadModifier {
 		// test here
 	}
 
+	@TestTemplate
+	public void doSomethingWithTemplateWorks() {
+		// test here
+	}
+
+	@TestTemplate
+	private void doSomethingElseWithTemplateWorks() {
+		// test here
+	}
+
 }


### PR DESCRIPTION
Hi,

when looking at some tests in Spring-Boot - e.g. [EmbeddedServletContainerJarDevelopmentIntegrationTests](https://github.com/spring-projects/spring-boot/blob/master/spring-boot-tests/spring-boot-integration-tests/spring-boot-server-tests/src/test/java/org/springframework/boot/context/embedded/EmbeddedServletContainerJarDevelopmentIntegrationTests.java)  - I was wondering if we should extend the `SpringJUnit5` rule with the functionality to apply its modifier visibility checks to methods annotated with `@TestTemplate`. This PR is an attempt to do so.

Let me know what you think.
Cheers,
Christoph