### PR TITLE
NullPointerException in Eclipse when using both the Spring Java Format plugin and the Checkstyle plugin

### DIFF
--- a/spring-javaformat-eclipse/io.spring.javaformat.eclipse/build.properties
+++ b/spring-javaformat-eclipse/io.spring.javaformat.eclipse/build.properties
@@ -4,6 +4,6 @@ bin.includes = META-INF/,\
                plugin.xml,\
                lifecycle-mapping-metadata.xml,\
                lib/spring-javaformat-formatter-eclipse.jar,\
-               lib/spring-javaformat-formatter.jar,
+               lib/spring-javaformat-formatter.jar,\
                lib/spring-javaformat-checkstyle.jar
 


### PR DESCRIPTION
This resolves #178 . The library was declared in the `build.properties`. But the missing backslash caused it to be ignored.