### PR TITLE
Add checkstyle rule for method javadoc whitespace

### DIFF
--- a/spring-javaformat/spring-javaformat-checkstyle/src/main/java/io/spring/javaformat/checkstyle/check/SpringJavadocCheck.java
+++ b/spring-javaformat/spring-javaformat-checkstyle/src/main/java/io/spring/javaformat/checkstyle/check/SpringJavadocCheck.java
@@ -53,6 +53,8 @@ public class SpringJavadocCheck extends AbstractSpringCheck {
 
 	private static final Pattern SINCE_TAG_PATTERN = Pattern.compile("@since\\s+(.*)");
 
+	private static final Pattern PARAM_TAG_PATTERN = Pattern.compile("@param\\s+(.*)");
+
 	private static final Set<Integer> TOP_LEVEL_TYPES;
 	static {
 		Set<Integer> topLevelTypes = new HashSet<Integer>();
@@ -93,6 +95,22 @@ public class SpringJavadocCheck extends AbstractSpringCheck {
 		checkBannedTags(ast, javadoc);
 		checkTagCase(ast, javadoc);
 		checkSinceTag(ast, javadoc);
+		checkMethodJavaDoc(ast, javadoc);
+	}
+
+	private void checkMethodJavaDoc(DetailAST ast, TextBlock javadoc) {
+		if (TokenTypes.METHOD_DEF != ast.getType()) {
+			return;
+		}
+		else {
+			String[] text = javadoc.getText();
+			for (int i = 0; i < text.length; i++) {
+				Matcher matcher = SINCE_TAG_PATTERN.matcher(text[i]);
+				if (matcher.find() && text[i - 1].trim().equals("*")) {
+					log(javadoc.getStartLineNo() + i - 1, 0, "javadoc.whiteSpace");
+				}
+			}
+		}
 	}
 
 	private void checkBannedTags(DetailAST ast, TextBlock javadoc) {

--- a/spring-javaformat/spring-javaformat-checkstyle/src/main/resources/io/spring/javaformat/checkstyle/check/messages.properties
+++ b/spring-javaformat/spring-javaformat-checkstyle/src/main/resources/io/spring/javaformat/checkstyle/check/messages.properties
@@ -6,6 +6,7 @@ javadoc.badCase=Javadoc element descriptions should not start with an uppercase 
 javadoc.bannedTag=Javadoc tag ''{0}'' should not be used.
 javadoc.missingSince=Missing Javadoc @since tag.
 javadoc.publicSince=Javadoc @since tag should not be used on private classes.
+javadoc.whiteSpace=Line matches the illegal pattern 'Trailing whitespace'.
 junit5.bannedImport=Import ''{0}'' should not be used in a JUnit 5 test.
 junit5.bannedTestAnnotation=JUnit 4 @Test annotation should not be used in a JUnit 5 test.
 junit5.lifecyclePrivateMethod=Lifecycle method ''{0}'' should not be private.

--- a/spring-javaformat/spring-javaformat-checkstyle/src/test/resources/check/JavadocWhiteSpace.txt
+++ b/spring-javaformat/spring-javaformat-checkstyle/src/test/resources/check/JavadocWhiteSpace.txt
@@ -1,0 +1,1 @@
++JavaDocWhiteSpace.java:25: Line matches the illegal pattern 'Trailing whitespace'.

--- a/spring-javaformat/spring-javaformat-checkstyle/src/test/resources/source/JavaDocWhiteSpace.java
+++ b/spring-javaformat/spring-javaformat-checkstyle/src/test/resources/source/JavaDocWhiteSpace.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Javadoc with white space.
+ * @param <T> this is a valid param
+ * @author Sushant Kumar Singh
+ */
+public class JavaDocWhiteSpace<T> {
+	/**
+	 * Do something.
+	 * 
+	 * @param something a lovely thing
+	 */
+	public void test(String something) {
+	}
+
+}


### PR DESCRIPTION
Javadoc for a method, cannot have white space after description.

E.g.

```
/**
 * description
 *
 * @param someParam a param
 */
```

Closes #16 