### PR TITLE
Initial support for ".editorconfig" file

### DIFF
--- a/spring-javaformat-gradle/spring-javaformat-gradle-plugin/src/main/java/io/spring/javaformat/gradle/FormatterTask.java
+++ b/spring-javaformat-gradle/spring-javaformat-gradle-plugin/src/main/java/io/spring/javaformat/gradle/FormatterTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,22 @@
 
 package io.spring.javaformat.gradle;
 
+import java.io.File;
 import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.SourceTask;
 
+import io.spring.javaformat.formatter.EditorConfigManager;
 import io.spring.javaformat.formatter.FileEdit;
 import io.spring.javaformat.formatter.FileFormatter;
 
@@ -30,10 +39,13 @@ import io.spring.javaformat.formatter.FileFormatter;
  * Abstract base class for formatter tasks.
  *
  * @author Phillip Webb
+ * @author Tadaya Tsuyukubo
  */
 abstract class FormatterTask extends SourceTask {
 
 	private String encoding;
+
+	private EditorConfigManager editorConfigManager = new EditorConfigManager();
 
 	/**
 	 * Get the file encoding in use.
@@ -57,10 +69,39 @@ abstract class FormatterTask extends SourceTask {
 	 * Format the source files and provide a {@link Stream} of {@link FileEdit} instances.
 	 * @return the file edits
 	 */
+	@SuppressWarnings("unchecked")
 	protected final Stream<FileEdit> formatFiles() {
-		FileFormatter formatter = new FileFormatter();
+		Set<File> files = getSource().getFiles();
+
+		// group by suffix
+		Map<String, List<File>> filesByType = files.stream().collect(
+				Collectors.groupingBy(file -> {
+					String filename = file.getName();
+					int lastIndex = filename.lastIndexOf(".");
+					if (lastIndex < 0) {
+						return "";
+					}
+					return filename.substring(lastIndex + 1);
+				}));
+
+		String projectDir = getPath();
 		Charset encoding = (getEncoding() != null ? Charset.forName(getEncoding()) : Charset.defaultCharset());
-		return formatter.formatFiles(getSource().getFiles(), encoding);
+
+		List<Stream<FileEdit>> list = new ArrayList<>();
+		for (List<File> filesToFormat : filesByType.values()) {
+			File firstFile = filesToFormat.get(0);
+			Map<String, String> options = this.editorConfigManager.getProperties(firstFile, projectDir);
+
+			FileFormatter formatter = new FileFormatter();
+			for (Entry<String, String> entry : options.entrySet()) {
+				formatter.addOrReplaceOption(entry.getKey(), entry.getValue());
+			}
+			Stream<FileEdit> stream = formatter.formatFiles(filesToFormat, encoding);
+			list.add(stream);
+		}
+
+		Stream<FileEdit>[] array = list.toArray(new Stream[0]);
+		return Stream.of(array).flatMap(Function.identity());
 	}
 
 }

--- a/spring-javaformat-intellij-idea/spring-javaformat-intellij-idea-plugin/src/main/java/io/spring/format/formatter/intellij/codestyle/SpringReformatter.java
+++ b/spring-javaformat-intellij-idea/spring-javaformat-intellij-idea-plugin/src/main/java/io/spring/format/formatter/intellij/codestyle/SpringReformatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 the original author or authors.
+ * Copyright 2017-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,10 @@
 
 package io.spring.format.formatter.intellij.codestyle;
 
+import java.nio.file.Path;
 import java.util.Collection;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.function.Supplier;
 
 import com.intellij.core.CoreBundle;
@@ -37,6 +40,7 @@ import com.intellij.util.IncorrectOperationException;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.text.edits.TextEdit;
 
+import io.spring.javaformat.formatter.EditorConfigManager;
 import io.spring.javaformat.formatter.Formatter;
 
 /**
@@ -44,6 +48,7 @@ import io.spring.javaformat.formatter.Formatter;
  * apply and to perform the actual formatting.
  *
  * @author Phillip Webb
+ * @author Tadaya Tsuyukubo
  */
 class SpringReformatter {
 
@@ -56,6 +61,8 @@ class SpringReformatter {
 	private final Supplier<Application> application;
 
 	private final Supplier<PsiDocumentManager> documentManager;
+
+	private EditorConfigManager editorConfigManager = new EditorConfigManager();
 
 	SpringReformatter(Supplier<Project> project) {
 		this.project = project;
@@ -102,7 +109,15 @@ class SpringReformatter {
 
 	private void reformat(PsiFile file, Collection<TextRange> ranges, Document document) {
 		if (document != null) {
+			Path path = file.getVirtualFile().toNioPath();
+			String projectRootPath = file.getProject().getBasePath();
+			Map<String, String> options = this.editorConfigManager.getProperties(path.toFile(), projectRootPath);
+
 			Formatter formatter = new Formatter();
+			for (Entry<String, String> entry : options.entrySet()) {
+				formatter.addOrReplaceOption(entry.getKey(), entry.getValue());
+			}
+
 			String source = document.getText();
 			IRegion[] regions = EclipseRegionAdapter.asArray(ranges);
 			TextEdit edit = formatter.format(source, regions, NORMALIZED_LINE_SEPARATOR);

--- a/spring-javaformat-intellij-idea/spring-javaformat-intellij-idea-plugin/src/test/java/io/spring/format/formatter/intellij/codestyle/SpringReformatterTests.java
+++ b/spring-javaformat-intellij-idea/spring-javaformat-intellij-idea-plugin/src/test/java/io/spring/format/formatter/intellij/codestyle/SpringReformatterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 the original author or authors.
+ * Copyright 2017-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.spring.format.formatter.intellij.codestyle;
 
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.function.Supplier;
@@ -24,6 +25,7 @@ import com.intellij.openapi.application.Application;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.TextRange;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiFile;
 import com.intellij.util.IncorrectOperationException;
@@ -93,6 +95,10 @@ public class SpringReformatterTests {
 
 	@Test
 	public void reformatShouldReformatDocument() throws Exception {
+		VirtualFile vf = mock(VirtualFile.class);
+		given(vf.toNioPath()).willReturn(Path.of("/"));
+		given(this.file.getVirtualFile()).willReturn(vf);
+		given(this.file.getProject()).willReturn(this.project);
 		given(this.file.isWritable()).willReturn(true);
 		Document document = mock(Document.class);
 		String text = "public class Hello {}";

--- a/spring-javaformat-maven/spring-javaformat-maven-plugin/src/main/java/io/spring/format/maven/ApplyMojo.java
+++ b/spring-javaformat-maven/spring-javaformat-maven-plugin/src/main/java/io/spring/format/maven/ApplyMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 the original author or authors.
+ * Copyright 2017-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,16 @@ package io.spring.format.maven;
 import java.io.File;
 import java.nio.charset.Charset;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 
+import io.spring.javaformat.formatter.EditorConfigManager;
 import io.spring.javaformat.formatter.FileEdit;
 import io.spring.javaformat.formatter.FileFormatter;
 import io.spring.javaformat.formatter.FileFormatterException;
@@ -33,6 +37,7 @@ import io.spring.javaformat.formatter.FileFormatterException;
  * Applies source formatting to the codebase.
  *
  * @author Phillip Webb
+ * @author Tadaya Tsuyukubo
  */
 @Mojo(name = "apply", defaultPhase = LifecyclePhase.PROCESS_SOURCES, threadSafe = true)
 public class ApplyMojo extends FormatMojo {
@@ -40,13 +45,37 @@ public class ApplyMojo extends FormatMojo {
 	@Override
 	protected void execute(List<File> files, Charset encoding, String lineSeparator)
 			throws MojoExecutionException, MojoFailureException {
+
+		// group by suffix
+		Map<String, List<File>> filesByType = files.stream().collect(
+				Collectors.groupingBy(file -> {
+					String filename = file.getName();
+					int lastIndex = filename.lastIndexOf(".");
+					if (lastIndex < 0) {
+						return "";
+					}
+					return filename.substring(lastIndex + 1);
+				}));
+
+		String projDir = this.project.getBasedir().getPath();
+
+		EditorConfigManager editorConfigManager = new EditorConfigManager();
 		try {
-			FileFormatter formatter = new FileFormatter();
-			formatter.formatFiles(files, encoding, lineSeparator).filter(FileEdit::hasEdits).forEach(this::save);
+			for (List<File> filesToFormat : filesByType.values()) {
+				File firstFile = filesToFormat.get(0);
+				Map<String, String> options = editorConfigManager.getProperties(firstFile, projDir);
+
+				FileFormatter formatter = new FileFormatter();
+				for (Entry<String, String> entry : options.entrySet()) {
+					formatter.addOrReplaceOption(entry.getKey(), entry.getValue());
+				}
+				formatter.formatFiles(files, encoding, lineSeparator).filter(FileEdit::hasEdits).forEach(this::save);
+			}
 		}
 		catch (FileFormatterException ex) {
 			throw new MojoExecutionException("Unable to format file " + ex.getFile(), ex);
 		}
+
 	}
 
 	private void save(FileEdit edit) {

--- a/spring-javaformat/spring-javaformat-formatter-shaded/pom.xml
+++ b/spring-javaformat/spring-javaformat-formatter-shaded/pom.xml
@@ -62,6 +62,7 @@
 					<artifactSet>
 						<includes>
 							<include>io.spring.javaformat:*</include>
+							<include>org.standardout.org.editorconfig:*</include>
 						</includes>
 					</artifactSet>
 					<relocations>
@@ -76,6 +77,10 @@
 						<relocation>
 							<pattern>org.osgi</pattern>
 							<shadedPattern>io.spring.javaformat.org.osgi</shadedPattern>
+						</relocation>
+						<relocation>
+							<pattern>org.editorconfig</pattern>
+							<shadedPattern>io.spring.javaformat.org.editorconfig</shadedPattern>
 						</relocation>
 					</relocations>
 					<transformers>

--- a/spring-javaformat/spring-javaformat-formatter/pom.xml
+++ b/spring-javaformat/spring-javaformat-formatter/pom.xml
@@ -12,6 +12,7 @@
 	<name>Spring JavaFormat Formatter</name>
 	<properties>
 		<main.basedir>${basedir}/../..</main.basedir>
+		<editorconfig.version>0.12.1.Final</editorconfig.version>
 	</properties>
 	<dependencies>
 		<!-- Compile -->
@@ -19,6 +20,11 @@
 			<groupId>io.spring.javaformat</groupId>
 			<artifactId>spring-javaformat-formatter-eclipse</artifactId>
 			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.standardout.org.editorconfig</groupId>
+			<artifactId>editorconfig-core</artifactId>
+			<version>${editorconfig.version}</version>
 		</dependency>
 		<!-- Provided -->
 		<dependency>

--- a/spring-javaformat/spring-javaformat-formatter/src/main/java/io/spring/javaformat/formatter/EditorConfigManager.java
+++ b/spring-javaformat/spring-javaformat-formatter/src/main/java/io/spring/javaformat/formatter/EditorConfigManager.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2017-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.javaformat.formatter;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.editorconfig.core.EditorConfig;
+import org.editorconfig.core.EditorConfig.OutPair;
+import org.editorconfig.core.EditorConfigException;
+
+/**
+ * Handles properties from ".editorconfig" file.
+ *
+ * @author Tadaya Tsuyukubo
+ */
+public class EditorConfigManager {
+
+	private static final Set<String> PROPERTIES_TO_IGNORE =
+			Collections.unmodifiableSet(new HashSet<>(Arrays.asList("tab_width",
+					"end_of_line", "charset", "trim_trailing_whitespace", "root")));
+
+	private final EditorConfig editorConfig;
+
+	public EditorConfigManager() {
+		this(new EditorConfig());
+	}
+
+	public EditorConfigManager(EditorConfig editorConfig) {
+		this.editorConfig = editorConfig;
+	}
+
+	public Map<String, String> getProperties(File file, String explicitRootDir) {
+		List<OutPair> pairs;
+		try {
+			pairs = this.editorConfig.getProperties(file.getPath(), Collections.singleton(explicitRootDir));
+		}
+		catch (EditorConfigException ex) {
+			throw FileFormatterException.wrap(file, ex);
+		}
+
+		Optional<String> tabWidth = pairs.stream().filter((pair) -> "tab_width".equals(pair.getKey()))
+				.map(OutPair::getVal)
+				.findFirst();
+
+		Map<String, String> props = new LinkedHashMap<>();
+		for (OutPair pair : pairs) {
+			String key = pair.getKey();
+			String value = pair.getVal();
+
+			// Handle well known properties
+			// https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties
+			if ("indent_style".equals(key)) {
+				if ("tab".equals(value) || "space".equals(value)) {
+					props.put("org.eclipse.jdt.core.formatter.tabulation.char", value);
+				}
+			}
+			else if ("indent_size".equals(key)) {
+				boolean useTabWidth = "tab".equals(value) && tabWidth.isPresent();
+				String tabSize = useTabWidth ? tabWidth.get() : value;
+				try {
+					Integer.parseInt(tabSize);
+					props.put("org.eclipse.jdt.core.formatter.tabulation.size", tabSize);
+				}
+				catch (NumberFormatException ex) {
+				}
+			}
+			else if ("insert_final_newline".equals(key)) {
+				String val = "true".equals(value) ? "insert" : "do not insert";
+				props.put("org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing", val);
+			}
+			else if (PROPERTIES_TO_IGNORE.contains(key)) {
+				// ignore
+			}
+			else {
+				props.put(key, value);
+			}
+		}
+
+		return props;
+	}
+
+}

--- a/spring-javaformat/spring-javaformat-formatter/src/main/java/io/spring/javaformat/formatter/FileFormatter.java
+++ b/spring-javaformat/spring-javaformat-formatter/src/main/java/io/spring/javaformat/formatter/FileFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 the original author or authors.
+ * Copyright 2017-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -120,6 +120,10 @@ public class FileFormatter {
 		catch (Exception ex) {
 			throw FileFormatterException.wrap(file, ex);
 		}
+	}
+
+	public void addOrReplaceOption(String key, String value) {
+		this.formatter.addOrReplaceOption(key, value);
 	}
 
 }

--- a/spring-javaformat/spring-javaformat-formatter/src/main/java/io/spring/javaformat/formatter/Formatter.java
+++ b/spring-javaformat/spring-javaformat-formatter/src/main/java/io/spring/javaformat/formatter/Formatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 the original author or authors.
+ * Copyright 2017-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Properties;
@@ -58,7 +59,7 @@ public class Formatter extends CodeFormatter {
 
 	private final Set<FormatterOption> options;
 
-	private CodeFormatter delegate = new DelegateCodeFormatter();
+	private DelegateCodeFormatter delegate = new DelegateCodeFormatter();
 
 	/**
 	 * Create a new formatter instance.
@@ -178,6 +179,10 @@ public class Formatter extends CodeFormatter {
 
 	}
 
+	public void addOrReplaceOption(String key, String value) {
+		this.delegate.addOrReplaceOption(key, value);
+	}
+
 	/**
 	 * Internal delegate code formatter to apply Spring {@literal formatter.prefs} and add
 	 * {@link Preparator Preparators}.
@@ -192,7 +197,7 @@ public class Formatter extends CodeFormatter {
 				Properties properties = new Properties();
 				try (InputStream inputStream = Formatter.class.getResourceAsStream("formatter.prefs")) {
 					properties.load(inputStream);
-					OPTIONS = (Map) Collections.unmodifiableMap(properties);
+					OPTIONS = new HashMap<>((Map) properties);
 				}
 			}
 			catch (IOException ex) {
@@ -210,6 +215,10 @@ public class Formatter extends CodeFormatter {
 			super.setOptions(OPTIONS);
 		}
 
+		public void addOrReplaceOption(String key, String value) {
+			OPTIONS.put(key, value);
+			super.setOptions(OPTIONS);
+		}
 	}
 
 }


### PR DESCRIPTION
This commit introduces initial support for `.editorconfig` file.

It is supported in maven, gradle, and intellij plugins.
(no eclipse plugin yet)

Currently, well known properties, `indent_style`, `indent_size`,
`tab_width`, `tab_width` and `insert_final_newline` are supported.

Sample `.editorconfig` file:
```
[*.java]
indent_style=space
indent_size=4
```

Or, user can specify eclipse properties avaiable for `Formatter`:
```
[*.java]
org.eclipse.jdt.core.formatter.tabulation.char=tab
```

Details:
- Allow option override in Formatter
- Add editorconfig-core library dependency
- Shade editorconfig-core library

Signed-off-by: Tadaya Tsuyukubo <tadaya@ttddyy.net>