### PR TITLE
use accessModifiers in JavadocVariableCheck

### DIFF
--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -92,7 +92,7 @@
 		</module>
 		<module name="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck" />
 		<module name="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocVariableCheck">
-			<property name="scope" value="public"/>
+			<property name="accessModifiers" value="public"/>
 		</module>
 		<module name="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck">
 			<property name="checkEmptyJavadoc" value="true"/>


### PR DESCRIPTION
Checkstyle has changed the `scope` property to `accessModifiers` in `JavadocVariableCheck`. This PR will update spring-javaformat's Checkstyle config to accommodate this (breaking) change, which will be included in an upcoming Checkstyle release. When the corresponding Checkstyle version is released, I will turn this draft PR into a (regular) PR and update the Checkstyle version number.

The breaking Checkstyle change is subject of https://github.com/checkstyle/checkstyle/pull/9277 ([comment mentioning spring-javaformat](https://github.com/checkstyle/checkstyle/pull/9277#issuecomment-835532021)).