### PR TITLE
fix: No enum constant io.spring.javaformat.config.JavaBaseline.v8

### DIFF
--- a/spring-javaformat/spring-javaformat-config/src/main/java/io/spring/javaformat/config/PropertiesJavaFormatConfig.java
+++ b/spring-javaformat/spring-javaformat-config/src/main/java/io/spring/javaformat/config/PropertiesJavaFormatConfig.java
@@ -38,7 +38,7 @@ class PropertiesJavaFormatConfig implements JavaFormatConfig {
 	@Override
 	public JavaBaseline getJavaBaseline() {
 		Object value = this.properties.get("java-baseline");
-		return (value != null) ? JavaBaseline.valueOf("v" + value.toString().toUpperCase().trim())
+		return (value != null) ? JavaBaseline.valueOf("V" + value.toString().toUpperCase().trim())
 				: DEFAULT.getJavaBaseline();
 	}
 

--- a/spring-javaformat/spring-javaformat-config/src/test/java/io/spring/javaformat/config/PropertiesJavaFormatConfigTest.java
+++ b/spring-javaformat/spring-javaformat-config/src/test/java/io/spring/javaformat/config/PropertiesJavaFormatConfigTest.java
@@ -1,0 +1,54 @@
+package io.spring.javaformat.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import java.util.Properties;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class PropertiesJavaFormatConfigTest {
+
+    private JavaFormatConfig javaFormatConfig;
+
+    @Mock
+    private Properties properties;
+
+    private AutoCloseable closeable;
+
+    @BeforeEach
+    void setUp() {
+        closeable = MockitoAnnotations.openMocks(this);
+        javaFormatConfig = new PropertiesJavaFormatConfig(properties);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        closeable.close();
+    }
+
+    @Test
+    void getJavaBaselineWhenNullShouldReturnDefaultJavaBaseline() {
+        when(properties.get(anyString()))
+            .thenReturn(null);
+
+        JavaBaseline actual = javaFormatConfig.getJavaBaseline();
+
+        assertThat(actual).isEqualTo(JavaBaseline.V11);
+    }
+
+    @Test
+    void getJavaBaselineWhenSetAs8ShouldReturnJavaBaselineV8() {
+        when(properties.get(anyString()))
+            .thenReturn(8);
+
+        JavaBaseline actual = javaFormatConfig.getJavaBaseline();
+
+        assertThat(actual).isEqualTo(JavaBaseline.V8);
+    }
+}

--- a/spring-javaformat/spring-javaformat-config/src/test/java/io/spring/javaformat/config/PropertiesJavaFormatConfigTest.java
+++ b/spring-javaformat/spring-javaformat-config/src/test/java/io/spring/javaformat/config/PropertiesJavaFormatConfigTest.java
@@ -1,6 +1,7 @@
 package io.spring.javaformat.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -50,5 +51,15 @@ class PropertiesJavaFormatConfigTest {
         JavaBaseline actual = javaFormatConfig.getJavaBaseline();
 
         assertThat(actual).isEqualTo(JavaBaseline.V8);
+    }
+
+    @Test
+    void getJavaBaselineWhenUnrecognisedVersionShouldThrowException() {
+        when(properties.get(anyString()))
+            .thenReturn("Unkown");
+
+        assertThatThrownBy(() -> javaFormatConfig.getJavaBaseline())
+            .hasNoCause()
+            .hasMessage("No enum constant io.spring.javaformat.config.JavaBaseline.VUNKOWN");
     }
 }


### PR DESCRIPTION
Error when run `mvn spring-javaformat:validate` while `.springjavaformatconfig` set `java-baseline=8`
```
mvn spring-javaformat:validate -e
[INFO] Error stacktraces are turned on.
[INFO] Scanning for projects...
[INFO] 
[INFO] -----------------------< com.journal:tax-center >-----------------------
[INFO] Building jrnl-tax-center 0.2.1-PROD
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- spring-javaformat-maven-plugin:0.0.30:validate (default-cli) @ tax-center ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.435 s
[INFO] Finished at: 2022-02-02T21:31:42+07:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal io.spring.javaformat:spring-javaformat-maven-plugin:0.0.30:validate (default-cli) on project tax-center: Execution default-cli of goal io.spring.javaformat:spring-javaformat-maven-plugin:0.0.30:validate failed: No enum constant io.spring.javaformat.config.JavaBaseline.v8 -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal io.spring.javaformat:spring-javaformat-maven-plugin:0.0.30:validate (default-cli) on project tax-center: Execution default-cli of goal io.spring.javaformat:spring-javaformat-maven-plugin:0.0.30:validate failed: No enum constant io.spring.javaformat.config.JavaBaseline.v8
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:215)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:972)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:293)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:196)
    at sun.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:498)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
Caused by: org.apache.maven.plugin.PluginExecutionException: Execution default-cli of goal io.spring.javaformat:spring-javaformat-maven-plugin:0.0.30:validate failed: No enum constant io.spring.javaformat.config.JavaBaseline.v8
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:148)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:210)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:972)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:293)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:196)
    at sun.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:498)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
Caused by: java.lang.IllegalArgumentException: No enum constant io.spring.javaformat.config.JavaBaseline.v8
    at java.lang.Enum.valueOf (Enum.java:238)
    at io.spring.javaformat.config.JavaBaseline.valueOf (JavaBaseline.java:24)
    at io.spring.javaformat.config.PropertiesJavaFormatConfig.getJavaBaseline (PropertiesJavaFormatConfig.java:41)
    at io.spring.javaformat.formatter.Formatter.<init> (Formatter.java:78)
    at io.spring.javaformat.formatter.FileFormatter.<init> (FileFormatter.java:45)
    at io.spring.format.maven.FormatMojo.getFormatter (FormatMojo.java:192)
    at io.spring.format.maven.ValidateMojo.execute (ValidateMojo.java:53)
    at io.spring.format.maven.FormatMojo.execute (FormatMojo.java:129)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:210)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:972)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:293)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:196)
    at sun.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:498)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
[ERROR] 
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginExecutionException
```