### PR TITLE
Support up-to-date checking of format task

### DIFF
--- a/spring-javaformat-gradle/spring-javaformat-gradle-plugin/src/main/java/io/spring/javaformat/gradle/SpringJavaFormatPlugin.java
+++ b/spring-javaformat-gradle/spring-javaformat-gradle-plugin/src/main/java/io/spring/javaformat/gradle/SpringJavaFormatPlugin.java
@@ -27,6 +27,7 @@ import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
 
+import io.spring.javaformat.config.JavaFormatConfig;
 import io.spring.javaformat.gradle.tasks.CheckFormat;
 import io.spring.javaformat.gradle.tasks.Format;
 import io.spring.javaformat.gradle.tasks.FormatterTask;
@@ -78,6 +79,9 @@ public class SpringJavaFormatPlugin implements Plugin<Project> {
 		provider.configure((task) -> {
 			task.setDescription(desc + " for " + sourceSet.getName());
 			task.setSource(sourceSet.getAllJava());
+			JavaFormatConfig javaFormatConfig = JavaFormatConfig.findFrom(this.project.getProjectDir());
+			task.getJavaBaseline().convention(javaFormatConfig.getJavaBaseline());
+			task.getIndentationStyle().convention(javaFormatConfig.getIndentationStyle());
 		});
 		return provider;
 	}

--- a/spring-javaformat-gradle/spring-javaformat-gradle-plugin/src/main/java/io/spring/javaformat/gradle/tasks/Format.java
+++ b/spring-javaformat-gradle/spring-javaformat-gradle-plugin/src/main/java/io/spring/javaformat/gradle/tasks/Format.java
@@ -19,6 +19,11 @@ package io.spring.javaformat.gradle.tasks;
 import java.io.IOException;
 
 import org.gradle.api.GradleException;
+import org.gradle.api.file.FileTree;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.OutputFiles;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 
 import io.spring.javaformat.formatter.FileEdit;
@@ -51,4 +56,15 @@ public class Format extends FormatterTask {
 		}
 	}
 
+	@Override
+	@InputFiles
+	@PathSensitive(PathSensitivity.RELATIVE)
+	public FileTree getSource() {
+		return super.getSource();
+	}
+
+	@OutputFiles
+	public FileTree getOutputFiles() {
+		return super.getSource();
+	}
 }

--- a/spring-javaformat-gradle/spring-javaformat-gradle-plugin/src/test/java/io/spring/javaformat/gradle/FormatTaskTests.java
+++ b/spring-javaformat-gradle/spring-javaformat-gradle-plugin/src/test/java/io/spring/javaformat/gradle/FormatTaskTests.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 
 import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.TaskOutcome;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -48,6 +49,24 @@ public class FormatTaskTests {
 		File formattedFile = new File(this.gradleBuild.getProjectDir(), "src/main/java/simple/Simple.java");
 		String formattedContent = new String(Files.readAllBytes(formattedFile.toPath()));
 		assertThat(formattedContent).contains("class Simple {").contains("	public static void main");
+	}
+
+	@Test
+	public void checkUpTpDate() throws IOException {
+		GradleRunner runner = this.gradleBuild.source("src/test/resources/format").prepareRunner("format");
+
+		// 1) Actually format the sources.
+		BuildResult result1 = runner.build();
+		assertThat(result1.task(":formatMain").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+
+		// 2) No-op reformat the sources
+		// Not up-to-date yet because 1) changed the sources.
+		BuildResult result2 = runner.build();
+		assertThat(result2.task(":formatMain").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+
+		// 3) Now we should be up-to-date since 2) was effectively a no-op
+		BuildResult result3 = runner.build();
+		assertThat(result3.task(":formatMain").getOutcome()).isEqualTo(TaskOutcome.UP_TO_DATE);
 	}
 
 	@Test


### PR DESCRIPTION
The `format` tasks are currently always out-of-date because the task did not declare its outputs.

This also adds the JavaFormatConfig options as inputs to the tasks, so both the format and check tasks will be out-of-date, when the configuration changes.