### PR TITLE
Detect and preserve line separators instead of using system default

### DIFF
--- a/spring-javaformat-eclipse/io.spring.javaformat.eclipse.tests/src/io/spring/javaformat/eclipse/projectsettings/ProjectSettingsFilesTests.java
+++ b/spring-javaformat-eclipse/io.spring.javaformat.eclipse.tests/src/io/spring/javaformat/eclipse/projectsettings/ProjectSettingsFilesTests.java
@@ -95,7 +95,8 @@ public class ProjectSettingsFilesTests {
 		}).given(projectFile).setContents((InputStream) any(), anyInt(), any());
 		files.applyToProject(project, monitor);
 		verify(projectFile).setContents((InputStream) any(), eq(1), eq(monitor));
-		assertThat(out.toString(StandardCharsets.UTF_8)).isEqualTo("a=b\ny=z\n");
+		assertThat(out.toString(StandardCharsets.UTF_8))
+				.isEqualToNormalizingNewlines("a=b\ny=z\n");
 	}
 
 	private ProjectSettingsFile createPrefsFile() throws IOException {

--- a/spring-javaformat-maven/spring-javaformat-maven-plugin/src/it/.gitattributes
+++ b/spring-javaformat-maven/spring-javaformat-maven-plugin/src/it/.gitattributes
@@ -1,0 +1,2 @@
+# Test resources that need a predictable eol
+apply*/src/main/java/simple/Simple.java eol=lf

--- a/spring-javaformat-maven/spring-javaformat-maven-plugin/src/test/java/io/spring/format/maven/VerifyApply.java
+++ b/spring-javaformat-maven/spring-javaformat-maven-plugin/src/test/java/io/spring/format/maven/VerifyApply.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class VerifyApply {
 
-	private static final String LF = System.lineSeparator();
+	private static final String LF = "\n";
 
 	private static final String JAVA_FILE = "src/main/java/simple/Simple.java";
 

--- a/spring-javaformat/spring-javaformat-formatter-eclipse-jdk11/pom.xml
+++ b/spring-javaformat/spring-javaformat-formatter-eclipse-jdk11/pom.xml
@@ -173,6 +173,7 @@
 								<option>-keep class org.eclipse.jdt.core.formatter.** {*;}</option>
 								<option>-keep class org.eclipse.jdt.internal.formatter.** {*;}</option>
 								<option>-keep class org.eclipse.jface.text.Document {*;}</option>
+								<option>-keep class org.eclipse.jface.text.TextUtilities {*;}</option>
 								<option>-keep class
 									org.eclipse.jdt.internal.compiler.parser.TerminalTokens {*;}</option>
 								<option>-keep class org.eclipse.jdt.core.dom.TagElement {*;}</option>

--- a/spring-javaformat/spring-javaformat-formatter-eclipse-jdk8/pom.xml
+++ b/spring-javaformat/spring-javaformat-formatter-eclipse-jdk8/pom.xml
@@ -173,6 +173,7 @@
 								<option>-keep class org.eclipse.jdt.core.formatter.** {*;}</option>
 								<option>-keep class org.eclipse.jdt.internal.formatter.** {*;}</option>
 								<option>-keep class org.eclipse.jface.text.Document {*;}</option>
+								<option>-keep class org.eclipse.jface.text.TextUtilities {*;}</option>
 								<option>-keep class
 									org.eclipse.jdt.internal.compiler.parser.TerminalTokens {*;}</option>
 								<option>-keep class org.eclipse.jdt.core.dom.TagElement {*;}</option>

--- a/spring-javaformat/spring-javaformat-formatter-tests/src/test/resources/.gitattributes
+++ b/spring-javaformat/spring-javaformat-formatter-tests/src/test/resources/.gitattributes
@@ -1,0 +1,4 @@
+# Test resources that need specific eol
+**/correct-crlf.txt eol=crlf
+**/correct-cr.txt   eol=cr
+**/correct-lf.txt   eol=lf

--- a/spring-javaformat/spring-javaformat-formatter-tests/src/test/resources/expected/correct-cr.txt
+++ b/spring-javaformat/spring-javaformat-formatter-tests/src/test/resources/expected/correct-cr.txt
@@ -1,0 +1,1 @@
+package correct;public class CorrectCr {	public static void main(String[] args) throws Exception {		// FIXME	}}

--- a/spring-javaformat/spring-javaformat-formatter-tests/src/test/resources/expected/correct-crlf.txt
+++ b/spring-javaformat/spring-javaformat-formatter-tests/src/test/resources/expected/correct-crlf.txt
@@ -1,0 +1,9 @@
+package correct;
+
+public class CorrectCrlf {
+
+	public static void main(String[] args) throws Exception {
+		// FIXME
+	}
+
+}

--- a/spring-javaformat/spring-javaformat-formatter-tests/src/test/resources/expected/correct-lf.txt
+++ b/spring-javaformat/spring-javaformat-formatter-tests/src/test/resources/expected/correct-lf.txt
@@ -1,0 +1,9 @@
+package correct;
+
+public class CorrectLf {
+
+	public static void main(String[] args) throws Exception {
+		// FIXME
+	}
+
+}

--- a/spring-javaformat/spring-javaformat-formatter-tests/src/test/resources/source/correct-cr.txt
+++ b/spring-javaformat/spring-javaformat-formatter-tests/src/test/resources/source/correct-cr.txt
@@ -1,0 +1,1 @@
+package correct;public class CorrectCr {	public static void main(String[] args) throws Exception {		// FIXME	}}

--- a/spring-javaformat/spring-javaformat-formatter-tests/src/test/resources/source/correct-crlf.txt
+++ b/spring-javaformat/spring-javaformat-formatter-tests/src/test/resources/source/correct-crlf.txt
@@ -1,0 +1,9 @@
+package correct;
+
+public class CorrectCrlf {
+
+	public static void main(String[] args) throws Exception {
+		// FIXME
+	}
+
+}

--- a/spring-javaformat/spring-javaformat-formatter-tests/src/test/resources/source/correct-lf.txt
+++ b/spring-javaformat/spring-javaformat-formatter-tests/src/test/resources/source/correct-lf.txt
@@ -1,0 +1,9 @@
+package correct;
+
+public class CorrectLf {
+
+	public static void main(String[] args) throws Exception {
+		// FIXME
+	}
+
+}

--- a/spring-javaformat/spring-javaformat-formatter/src/main/java/io/spring/javaformat/formatter/Formatter.java
+++ b/spring-javaformat/spring-javaformat-formatter/src/main/java/io/spring/javaformat/formatter/Formatter.java
@@ -17,6 +17,8 @@
 package io.spring.javaformat.formatter;
 
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.text.edits.TextEdit;
@@ -55,6 +57,11 @@ public class Formatter {
 	 * The default indentation level.
 	 */
 	private static final int DEFAULT_INDENTATION_LEVEL = 0;
+
+	/**
+	 * Pattern that matches all line separators into named-capturing group "sep".
+	 */
+	private static final Pattern LINE_SEPARATOR_PATTERN = Pattern.compile("(?<sep>(\r\n|\r|\n))");
 
 	/**
 	 * The default line separator.
@@ -123,6 +130,9 @@ public class Formatter {
 
 	public TextEdit format(int kind, String source, int offset, int length, int indentationLevel,
 			String lineSeparator) {
+		if (lineSeparator == null) {
+			lineSeparator = detectLineSeparator(source);
+		}
 		return this.delegate.format(kind, source, offset, length, indentationLevel, lineSeparator);
 	}
 
@@ -148,6 +158,9 @@ public class Formatter {
 	}
 
 	public TextEdit format(int kind, String source, IRegion[] regions, int indentationLevel, String lineSeparator) {
+		if (lineSeparator == null) {
+			lineSeparator = detectLineSeparator(source);
+		}
 		return this.delegate.format(kind, source, regions, indentationLevel, lineSeparator);
 	}
 
@@ -159,4 +172,17 @@ public class Formatter {
 		this.delegate.setOptions(options);
 	}
 
+	private String detectLineSeparator(String contents) {
+		Matcher matcher = LINE_SEPARATOR_PATTERN.matcher(contents);
+		if (!matcher.find()) {
+			return DEFAULT_LINE_SEPARATOR;
+		}
+		String firstMatch = matcher.group("sep");
+		while (matcher.find()) {
+			if (!matcher.group("sep").equals(firstMatch)) {
+				return DEFAULT_LINE_SEPARATOR;
+			}
+		}
+		return firstMatch;
+	}
 }

--- a/spring-javaformat/spring-javaformat-formatter/src/main/java/io/spring/javaformat/formatter/Formatter.java
+++ b/spring-javaformat/spring-javaformat-formatter/src/main/java/io/spring/javaformat/formatter/Formatter.java
@@ -17,10 +17,9 @@
 package io.spring.javaformat.formatter;
 
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.TextUtilities;
 import org.eclipse.text.edits.TextEdit;
 
 import io.spring.javaformat.config.JavaBaseline;
@@ -57,11 +56,6 @@ public class Formatter {
 	 * The default indentation level.
 	 */
 	private static final int DEFAULT_INDENTATION_LEVEL = 0;
-
-	/**
-	 * Pattern that matches all line separators into named-capturing group "sep".
-	 */
-	private static final Pattern LINE_SEPARATOR_PATTERN = Pattern.compile("(?<sep>(\r\n|\r|\n))");
 
 	/**
 	 * The default line separator.
@@ -131,7 +125,7 @@ public class Formatter {
 	public TextEdit format(int kind, String source, int offset, int length, int indentationLevel,
 			String lineSeparator) {
 		if (lineSeparator == null) {
-			lineSeparator = detectLineSeparator(source);
+			lineSeparator = TextUtilities.determineLineDelimiter(source, DEFAULT_LINE_SEPARATOR);
 		}
 		return this.delegate.format(kind, source, offset, length, indentationLevel, lineSeparator);
 	}
@@ -159,7 +153,7 @@ public class Formatter {
 
 	public TextEdit format(int kind, String source, IRegion[] regions, int indentationLevel, String lineSeparator) {
 		if (lineSeparator == null) {
-			lineSeparator = detectLineSeparator(source);
+			lineSeparator = TextUtilities.determineLineDelimiter(source, DEFAULT_LINE_SEPARATOR);
 		}
 		return this.delegate.format(kind, source, regions, indentationLevel, lineSeparator);
 	}
@@ -172,17 +166,4 @@ public class Formatter {
 		this.delegate.setOptions(options);
 	}
 
-	private String detectLineSeparator(String contents) {
-		Matcher matcher = LINE_SEPARATOR_PATTERN.matcher(contents);
-		if (!matcher.find()) {
-			return DEFAULT_LINE_SEPARATOR;
-		}
-		String firstMatch = matcher.group("sep");
-		while (matcher.find()) {
-			if (!matcher.group("sep").equals(firstMatch)) {
-				return DEFAULT_LINE_SEPARATOR;
-			}
-		}
-		return firstMatch;
-	}
 }


### PR DESCRIPTION
Fixes #280 

The current behavior of `Formatter#format` falls back to the system default line separator when one isn't explicitly specified, causing a bunch of false positives when building on Windows machines with LF configured via `.gitconfig` or `.gitattributes`.
This modifies the behavior to instead detect a common line separator per source file, and only fall back to system default when one cannot be determined for some reason. 

(See linked issue for additional context)