### PR TITLE
Broaden Checkstyle rule for AssertJ assertion enforcement

### DIFF
--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -137,7 +137,7 @@
 		</module>
 		<module name="com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineJavaCheck">
 			<property name="maximum" value="0"/>
-			<property name="format" value="org\.junit\.Assert\.assert" />
+			<property name="format" value="org\.junit\.Assert|org\.junit\.jupiter\.api\.Assertions" />
 			<property name="message"
 				value="Please use AssertJ imports." />
 			<property name="ignoreComments" value="true" />


### PR DESCRIPTION
This PR updates the Checkstyle rule for AssertJ assertion enforcement to include JUnit Jupiter and broaden the scope of `org.junit.Assert` by removing the ".assert" part.