### PR TITLE
Allow static import of AssertJ BDDAssertions

### DIFF
--- a/spring-javaformat/spring-javaformat-checkstyle/src/main/java/io/spring/javaformat/checkstyle/check/SpringAvoidStaticImportCheck.java
+++ b/spring-javaformat/spring-javaformat-checkstyle/src/main/java/io/spring/javaformat/checkstyle/check/SpringAvoidStaticImportCheck.java
@@ -47,7 +47,6 @@ public class SpringAvoidStaticImportCheck extends AvoidStaticImportCheck {
 		excludes.add("org.junit.internal.matchers.ThrowableMessageMatcher.*");
 		excludes.add("org.junit.jupiter.api.Assertions.*");
 		excludes.add("org.junit.jupiter.api.Assumptions.*");
-		excludes.add("org.junit.jupiter.api.Assertions.*");
 		excludes.add("org.mockito.ArgumentMatchers.*");
 		excludes.add("org.mockito.BDDMockito.*");
 		excludes.add("org.mockito.Matchers.*");

--- a/spring-javaformat/spring-javaformat-checkstyle/src/main/java/io/spring/javaformat/checkstyle/check/SpringAvoidStaticImportCheck.java
+++ b/spring-javaformat/spring-javaformat-checkstyle/src/main/java/io/spring/javaformat/checkstyle/check/SpringAvoidStaticImportCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 the original author or authors.
+ * Copyright 2017-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ public class SpringAvoidStaticImportCheck extends AvoidStaticImportCheck {
 		excludes.add("io.restassured.RestAssured.*");
 		excludes.add("org.assertj.core.api.Assertions.*");
 		excludes.add("org.assertj.core.api.Assumptions.*");
+		excludes.add("org.assertj.core.api.BDDAssertions.*");
 		excludes.add("org.assertj.core.api.HamcrestCondition.*");
 		excludes.add("org.awaitility.Awaitility.*");
 		excludes.add("org.hamcrest.CoreMatchers.*");


### PR DESCRIPTION
Analogous to the allowed import `BDDMockito`, Spring JavaFormat should also allow static import of AssertJ's `BDDAssertions`.

Note that there's an additional commit in this PR that removes a duplicate exclude that has sneaked in.