### PR TITLE
Apply UnnecessarySemicolonInEnumeration Checkstyle module

### DIFF
--- a/spring-javaformat/spring-javaformat-checkstyle/src/main/resources/io/spring/javaformat/checkstyle/spring-checkstyle.xml
+++ b/spring-javaformat/spring-javaformat-checkstyle/src/main/resources/io/spring/javaformat/checkstyle/spring-checkstyle.xml
@@ -70,6 +70,7 @@
 			<property name="validateOnlyOverlapping" value="false" />
 		</module>
 		<module name="com.puppycrawl.tools.checkstyle.checks.coding.OneStatementPerLineCheck" />
+		<module name="com.puppycrawl.tools.checkstyle.checks.coding.UnnecessarySemicolonInEnumerationCheck"/>
 
 		<!-- Imports -->
 		<module name="com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck" />

--- a/spring-javaformat/spring-javaformat-checkstyle/src/test/java/io/spring/javaformat/checkstyle/SpringConfigurationLoaderTests.java
+++ b/spring-javaformat/spring-javaformat-checkstyle/src/test/java/io/spring/javaformat/checkstyle/SpringConfigurationLoaderTests.java
@@ -48,7 +48,7 @@ public class SpringConfigurationLoaderTests {
 		assertThat(checks).hasSize(5);
 		TreeWalker treeWalker = (TreeWalker) checks.toArray()[4];
 		Set<?> ordinaryChecks = (Set<?>) Extractors.byName("ordinaryChecks").extract(treeWalker);
-		assertThat(ordinaryChecks).hasSize(60);
+		assertThat(ordinaryChecks).hasSize(61);
 	}
 
 	@Test
@@ -59,7 +59,7 @@ public class SpringConfigurationLoaderTests {
 		assertThat(checks).hasSize(5);
 		TreeWalker treeWalker = (TreeWalker) checks.toArray()[4];
 		Set<?> ordinaryChecks = (Set<?>) Extractors.byName("ordinaryChecks").extract(treeWalker);
-		assertThat(ordinaryChecks).hasSize(59);
+		assertThat(ordinaryChecks).hasSize(60);
 	}
 
 	@Test

--- a/spring-javaformat/spring-javaformat-formatter-eclipse-jdt-jdk17/src/main/java/org/eclipse/jdt/internal/formatter/Preparator.java
+++ b/spring-javaformat/spring-javaformat-formatter-eclipse-jdt-jdk17/src/main/java/org/eclipse/jdt/internal/formatter/Preparator.java
@@ -54,7 +54,7 @@ public interface Preparator {
 		/**
 		 * Apply the preparator after wrapping.
 		 */
-		POST_WRAPPING;
+		POST_WRAPPING
 
 	}
 

--- a/spring-javaformat/spring-javaformat-formatter-eclipse-jdt-jdk8/src/main/java/org/eclipse/jdt/internal/formatter/Preparator.java
+++ b/spring-javaformat/spring-javaformat-formatter-eclipse-jdt-jdk8/src/main/java/org/eclipse/jdt/internal/formatter/Preparator.java
@@ -54,7 +54,7 @@ public interface Preparator {
 		/**
 		 * Apply the preparator after wrapping.
 		 */
-		POST_WRAPPING;
+		POST_WRAPPING
 
 	}
 

--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -65,6 +65,7 @@
 			<property name="validateOnlyOverlapping" value="false" />
 		</module>
 		<module name="com.puppycrawl.tools.checkstyle.checks.coding.OneStatementPerLineCheck" />
+		<module name="com.puppycrawl.tools.checkstyle.checks.coding.UnnecessarySemicolonInEnumerationCheck"/>
 
 		<!-- Imports -->
 		<module name="com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck" />


### PR DESCRIPTION
This PR applies the `UnnecessarySemicolonInEnumeration` Checkstyle module.

This PR also applies it to this project itself and fixes its violations.

See https://github.com/spring-projects/spring-framework/pull/32514 and https://github.com/spring-projects/spring-boot/commit/9cdd0c3776d09587f93baf6261c621eae60faa09