### PR TITLE
Polish sample in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -391,7 +391,7 @@ For example:
 
 [source,java,indent=0,subs="normal"]
 ----
-class Name {
+public class Name {
 
 	private final String first;
 


### PR DESCRIPTION
The constructor is `public`, so it would be better for the class to be also `public` as a sample.