### PR TITLE
UnsupportedOperationException when creating 'scratch file' in IntelliJ IDEA

### DIFF
--- a/spring-javaformat-intellij-idea/spring-javaformat-intellij-idea-plugin/src/main/java/io/spring/format/formatter/intellij/formatting/SpringJavaFormatFormattingService.java
+++ b/spring-javaformat-intellij-idea/spring-javaformat-intellij-idea-plugin/src/main/java/io/spring/format/formatter/intellij/formatting/SpringJavaFormatFormattingService.java
@@ -78,7 +78,7 @@ public class SpringJavaFormatFormattingService extends AbstractDocumentFormattin
 	public void formatDocument(@NotNull Document document, @NotNull List<TextRange> formattingRanges,
 			@NotNull FormattingContext formattingContext, boolean canChangeWhiteSpaceOnly, boolean quickFormat) {
 		VirtualFile file = formattingContext.getVirtualFile();
-		Path path = (file != null) ? file.toNioPath() : null;
+		Path path = (file != null) ? file.getFileSystem().getNioPath(file) : null;
 		JavaFormatConfig config = JavaFormatConfig.findFrom(path);
 		Formatter formatter = new Formatter(config);
 		String source = document.getText();


### PR DESCRIPTION
At the moment, whenever you try to create a new scratch file, you get the following exception:
<img width="346" alt="Screenshot 2025-05-19 at 11 58 32" src="https://github.com/user-attachments/assets/bab0e29d-fb1b-4237-a97b-54e90a544e43" />


```
java.lang.UnsupportedOperationException: Failed to map LightVirtualFile: /a.java (filesystem com.intellij.testFramework.LightVirtualFileBase$MyVirtualFileSystem@70a3c41) into nio Path
	at com.intellij.openapi.vfs.VirtualFile.toNioPath(VirtualFile.java:165)
	at io.spring.format.formatter.intellij.formatting.SpringJavaFormatFormattingService.formatDocument(SpringJavaFormatFormattingService.java:81)
	at com.intellij.formatting.service.AbstractDocumentFormattingService.formatElement(AbstractDocumentFormattingService.java:47)
	at com.intellij.formatting.service.AbstractDocumentFormattingService.formatElement(AbstractDocumentFormattingService.java:31)
	at com.intellij.formatting.service.FormattingServiceUtil.formatElement(FormattingServiceUtil.java:67)
	at com.intellij.psi.impl.source.codeStyle.CodeStyleManagerImpl.reformat(CodeStyleManagerImpl.java:82)
	at com.intellij.psi.impl.source.codeStyle.CodeStyleManagerImpl.reformat(CodeStyleManagerImpl.java:66)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at krasa.formatter.plugin.ProxyCodeStyleManagerDelegator.PLEASE_REPORT_BUGS_TO_JETBRAINS_IF_IT_FAILS_HERE____ORIGINAL_INTELLIJ_FORMATTER_WAS_USED(ProxyCodeStyleManagerDelegator.java:60)
	at krasa.formatter.plugin.ProxyCodeStyleManagerDelegator.invoke(ProxyCodeStyleManagerDelegator.java:28)
	at net.sf.cglib.empty.Object$$EnhancerByCGLIB$$a6c18dd5.reformat(<generated>)
	at com.intellij.ide.scratch.ScratchFileCreationHelper.lambda$reformat$0(ScratchFileCreationHelper.java:70)
	at com.intellij.openapi.command.WriteCommandAction.lambda$runWriteCommandAction$5(WriteCommandAction.java:345)
	at com.intellij.openapi.command.WriteCommandAction$BuilderImpl.lambda$compute$3(WriteCommandAction.java:164)
	at com.intellij.openapi.command.WriteCommandAction$BuilderImpl.lambda$doRunWriteCommandAction$1(WriteCommandAction.java:147)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteAction$lambda$13(AnyThreadWriteThreadingSupport.kt:613)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteAction$lambda$15(AnyThreadWriteThreadingSupport.kt:623)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWithTemporaryThreadLocal(AnyThreadWriteThreadingSupport.kt:204)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteAction(AnyThreadWriteThreadingSupport.kt:623)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteAction(AnyThreadWriteThreadingSupport.kt:613)
	at com.intellij.openapi.application.impl.ApplicationImpl.runWriteAction(ApplicationImpl.java:988)
	at com.intellij.openapi.command.WriteCommandAction$BuilderImpl.lambda$doRunWriteCommandAction$2(WriteCommandAction.java:145)
	at com.intellij.openapi.command.impl.CoreCommandProcessor.lambda$executeCommand$2(CoreCommandProcessor.java:228)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteIntentReadAction$lambda$6(AnyThreadWriteThreadingSupport.kt:274)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWithTemporaryThreadLocal(AnyThreadWriteThreadingSupport.kt:204)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteIntentReadAction(AnyThreadWriteThreadingSupport.kt:274)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteIntentReadAction(AnyThreadWriteThreadingSupport.kt:222)
	at com.intellij.openapi.application.impl.ApplicationImpl.runWriteIntentReadAction(ApplicationImpl.java:1009)
	at com.intellij.openapi.command.impl.CoreCommandProcessor.executeCommand(CoreCommandProcessor.java:224)
	at com.intellij.openapi.command.impl.CoreCommandProcessor.executeCommand(CoreCommandProcessor.java:189)
	at com.intellij.openapi.command.WriteCommandAction$BuilderImpl.doRunWriteCommandAction(WriteCommandAction.java:154)
	at com.intellij.openapi.command.WriteCommandAction$BuilderImpl.run(WriteCommandAction.java:121)
	at com.intellij.openapi.command.WriteCommandAction$BuilderImpl.compute(WriteCommandAction.java:164)
	at com.intellij.openapi.command.WriteCommandAction.runWriteCommandAction(WriteCommandAction.java:345)
	at com.intellij.ide.scratch.ScratchFileCreationHelper.reformat(ScratchFileCreationHelper.java:68)
	at com.intellij.ide.actions.JavaScratchFileCreationHelper.prepareText(JavaScratchFileCreationHelper.java:23)
	at com.intellij.ide.scratch.ScratchFileActions.doCreateNewScratch(ScratchFileActions.java:250)
	at com.intellij.ide.scratch.ScratchFileActions.doCreateNewScratch(ScratchFileActions.java:232)
	at com.intellij.ide.scratch.ScratchFileActions$NewFileAction.lambda$actionPerformed$2(ScratchFileActions.java:133)
	at com.intellij.ide.scratch.LRUPopupBuilder$2.lambda$onChosen$0(LRUPopupBuilder.java:190)
	at com.intellij.ui.popup.AbstractPopup.lambda$dispose$21(AbstractPopup.java:2011)
	at com.intellij.openapi.application.WriteIntentReadAction.lambda$run$0(WriteIntentReadAction.java:24)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteIntentReadAction$lambda$6(AnyThreadWriteThreadingSupport.kt:274)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWithTemporaryThreadLocal(AnyThreadWriteThreadingSupport.kt:204)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteIntentReadAction(AnyThreadWriteThreadingSupport.kt:274)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteIntentReadAction(AnyThreadWriteThreadingSupport.kt:222)
	at com.intellij.openapi.application.impl.ApplicationImpl.runWriteIntentReadAction(ApplicationImpl.java:1009)
	at com.intellij.openapi.application.WriteIntentReadAction.compute(WriteIntentReadAction.java:55)
	at com.intellij.openapi.application.WriteIntentReadAction.run(WriteIntentReadAction.java:23)
	at com.intellij.openapi.wm.impl.FocusManagerImpl.lambda$doWhenFocusSettlesDown$4(FocusManagerImpl.java:178)
	at com.intellij.util.ui.EdtInvocationManager.invokeLaterIfNeeded(EdtInvocationManager.java:32)
	at com.intellij.openapi.wm.impl.FocusManagerImpl.doWhenFocusSettlesDown(FocusManagerImpl.java:173)
	at com.intellij.openapi.wm.impl.FocusManagerImpl.doWhenFocusSettlesDown(FocusManagerImpl.java:165)
	at com.intellij.ui.popup.AbstractPopup.dispose(AbstractPopup.java:2009)
	at com.intellij.ui.popup.WizardPopup.dispose(WizardPopup.java:175)
	at com.intellij.ui.popup.list.ListPopupImpl.dispose(ListPopupImpl.java:407)
	at com.intellij.openapi.util.ObjectTree.runWithTrace(ObjectTree.java:132)
	at com.intellij.openapi.util.ObjectTree.executeAll(ObjectTree.java:164)
	at com.intellij.openapi.util.Disposer.dispose(Disposer.java:205)
	at com.intellij.openapi.util.Disposer.dispose(Disposer.java:193)
	at com.intellij.ui.popup.WizardPopup.disposeAllParents(WizardPopup.java:303)
	at com.intellij.ui.popup.list.ListPopupImpl.disposePopup(ListPopupImpl.java:539)
	at com.intellij.ui.popup.list.ListPopupImpl.handleNextStep(ListPopupImpl.java:563)
	at com.intellij.ui.popup.list.ListPopupImpl._handleSelect(ListPopupImpl.java:524)
	at com.intellij.ui.popup.list.ListPopupImpl.handleSelect(ListPopupImpl.java:449)
	at com.intellij.ui.popup.list.ListPopupImpl$1.actionPerformed(ListPopupImpl.java:290)
	at com.intellij.ui.popup.WizardPopup.lambda$proceedKeyEvent$0(WizardPopup.java:433)
	at com.intellij.openapi.application.WriteIntentReadAction.lambda$run$0(WriteIntentReadAction.java:24)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteIntentReadAction$lambda$6(AnyThreadWriteThreadingSupport.kt:274)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWithTemporaryThreadLocal(AnyThreadWriteThreadingSupport.kt:204)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteIntentReadAction(AnyThreadWriteThreadingSupport.kt:274)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteIntentReadAction(AnyThreadWriteThreadingSupport.kt:222)
	at com.intellij.openapi.application.impl.ApplicationImpl.runWriteIntentReadAction(ApplicationImpl.java:1009)
	at com.intellij.openapi.application.WriteIntentReadAction.compute(WriteIntentReadAction.java:55)
	at com.intellij.openapi.application.WriteIntentReadAction.run(WriteIntentReadAction.java:23)
	at com.intellij.ui.popup.WizardPopup.proceedKeyEvent(WizardPopup.java:432)
	at com.intellij.ui.popup.WizardPopup.dispatch(WizardPopup.java:404)
	at com.intellij.ui.popup.PopupDispatcher.dispatchKeyEvent(PopupDispatcher.java:123)
	at com.intellij.ui.popup.PopupDispatcher.dispatch(PopupDispatcher.java:164)
	at com.intellij.ide.IdePopupManager.dispatch(IdePopupManager.java:96)
	at com.intellij.ide.IdeEventQueue._dispatchEvent$lambda$13(IdeEventQueue.kt:452)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteIntentReadAction$lambda$6(AnyThreadWriteThreadingSupport.kt:274)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWithTemporaryThreadLocal(AnyThreadWriteThreadingSupport.kt:204)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteIntentReadAction(AnyThreadWriteThreadingSupport.kt:274)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runPreventiveWriteIntentReadAction(AnyThreadWriteThreadingSupport.kt:218)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.kt:452)
	at com.intellij.ide.IdeEventQueue.dispatchEvent$lambda$12$lambda$11$lambda$10$lambda$9(IdeEventQueue.kt:307)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:864)
	at com.intellij.ide.IdeEventQueue.dispatchEvent$lambda$12$lambda$11$lambda$10(IdeEventQueue.kt:306)
	at com.intellij.ide.IdeEventQueueKt.performActivity$lambda$3(IdeEventQueue.kt:958)
	at com.intellij.openapi.application.TransactionGuardImpl.performActivity(TransactionGuardImpl.java:117)
	at com.intellij.ide.IdeEventQueueKt.performActivity(IdeEventQueue.kt:958)
	at com.intellij.ide.IdeEventQueue.dispatchEvent$lambda$12(IdeEventQueue.kt:301)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.kt:341)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:207)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:128)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:117)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:105)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:92)


```

