### PR TITLE
Allow Javadoc tag description to begin with an acronym

### DIFF
--- a/spring-javaformat/spring-javaformat-checkstyle/src/main/java/io/spring/javaformat/checkstyle/check/SpringJavadocCheck.java
+++ b/spring-javaformat/spring-javaformat-checkstyle/src/main/java/io/spring/javaformat/checkstyle/check/SpringJavadocCheck.java
@@ -154,7 +154,7 @@ public class SpringJavadocCheck extends AbstractSpringCheck {
 				Matcher matcher = pattern.matcher(text[i]);
 				if (matcher.find()) {
 					String description = matcher.group(1).trim();
-					if (startsWithUppercase(description)) {
+					if (!hasCorrectCase(description)) {
 						log(javadoc.getStartLineNo() + i, text[i].length() - description.length(), "javadoc.badCase");
 					}
 				}
@@ -245,27 +245,24 @@ public class SpringJavadocCheck extends AbstractSpringCheck {
 		}
 	}
 
-	private boolean startsWithUppercase(String description) {
-        if(description.length() > 0 || Character.isUpperCase(description.charAt(0))) {
-            return false;
-        }
-        return !startWithAcronym(description);
+	private boolean hasCorrectCase(String description) {
+		return startsWithAcronym(description) || !startsWithUppercase(description);
 	}
 
-    private boolean startWithAcronym(String description) {
-        int upperCount = 0;
-        for (int i = 0; i < description.length(); i++) {
-            char ch= description.charAt(i);
-            if (Character.isUpperCase(ch)) {
-                upperCount++;
-            }
-            else {
-                break;
-            }
+	private boolean startsWithUppercase(String description) {
+		return !description.isEmpty() && Character.isUpperCase(description.charAt(0));
+	}
 
-        }
-        return upperCount >= 2;
-    }
+	private boolean startsWithAcronym(String description) {
+		int i = 0;
+		while (i < description.length() && Character.isLetter(description.charAt(i))) {
+			if (!Character.isUpperCase(description.charAt(i))) {
+				return false;
+			}
+			i++;
+		}
+		return i >= 2;
+	}
 
 	private void checkForNonJavadocComments(TextBlock block) {
 		if (block == null) {

--- a/spring-javaformat/spring-javaformat-checkstyle/src/main/java/io/spring/javaformat/checkstyle/check/SpringJavadocCheck.java
+++ b/spring-javaformat/spring-javaformat-checkstyle/src/main/java/io/spring/javaformat/checkstyle/check/SpringJavadocCheck.java
@@ -35,6 +35,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * Checks that the javadoc comments follow Spring conventions.
  *
  * @author Phillip Webb
+ * @author Venkata Naga Sai Srikanth Gollapudi
  */
 public class SpringJavadocCheck extends AbstractSpringCheck {
 
@@ -245,8 +246,26 @@ public class SpringJavadocCheck extends AbstractSpringCheck {
 	}
 
 	private boolean startsWithUppercase(String description) {
-		return description.length() > 0 && Character.isUpperCase(description.charAt(0));
+        if(description.length() > 0 || Character.isUpperCase(description.charAt(0))) {
+            return false;
+        }
+        return !startWithAcronym(description);
 	}
+
+    private boolean startWithAcronym(String description) {
+        int upperCount = 0;
+        for (int i = 0; i < description.length(); i++) {
+            char ch= description.charAt(i);
+            if (Character.isUpperCase(ch)) {
+                upperCount++;
+            }
+            else {
+                break;
+            }
+
+        }
+        return upperCount >= 2;
+    }
 
 	private void checkForNonJavadocComments(TextBlock block) {
 		if (block == null) {

--- a/spring-javaformat/spring-javaformat-checkstyle/src/test/resources/source/JavadocValid.java
+++ b/spring-javaformat/spring-javaformat-checkstyle/src/test/resources/source/JavadocValid.java
@@ -47,14 +47,14 @@ public class JavadocValid<T> {
 	public String test3(String something) throws RuntimeException {
 	}
 
-    /**
-     * Do something with acronyms.
-     * @param something JNI hints for the thing
-     * @return the thing
-     * @throws RuntimeException on the error
-     */
-    public String test4(String something) throws RuntimeException {
-    }
+	/**
+	 * Do something with acronyms.
+	 * @param something JNI hints for the thing
+	 * @return the thing
+	 * @throws RuntimeException on the error
+	 */
+	public String test4(String something) throws RuntimeException {
+	}
 
 	/**
 	 * Class with a numeric date since.

--- a/spring-javaformat/spring-javaformat-checkstyle/src/test/resources/source/JavadocValid.java
+++ b/spring-javaformat/spring-javaformat-checkstyle/src/test/resources/source/JavadocValid.java
@@ -19,6 +19,7 @@
  *
  * @param <T> this is a valid param
  * @author Phillip Webb
+ * @author Venkata Naga Sai Srikanth Gollapudi
  */
 public class JavadocValid<T> {
 
@@ -45,6 +46,15 @@ public class JavadocValid<T> {
 	 */
 	public String test3(String something) throws RuntimeException {
 	}
+
+    /**
+     * Do something with acronyms.
+     * @param something JNI hints for the thing
+     * @return the thing
+     * @throws RuntimeException on the error
+     */
+    public String test4(String something) throws RuntimeException {
+    }
 
 	/**
 	 * Class with a numeric date since.


### PR DESCRIPTION
This Change updates the case check to allow descriptions that start with 2 or more consecutive uppercase letters(acronym), while still rejecting single capitalized words like "The" or "Url"

Examples Allowed: "HTML","URL","JNI"

Closes #468 