### PR TITLE
Add support for merging user settings with plugin default

### DIFF
--- a/spring-javaformat-eclipse/io.spring.javaformat.eclipse.tests/src/io/spring/javaformat/eclipse/projectsettings/ProjectSettingsFileTests.java
+++ b/spring-javaformat-eclipse/io.spring.javaformat.eclipse.tests/src/io/spring/javaformat/eclipse/projectsettings/ProjectSettingsFileTests.java
@@ -19,7 +19,9 @@ package io.spring.javaformat.eclipse.projectsettings;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.InputStream;
 import java.io.PrintWriter;
+import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -32,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link ProjectSettingsFile}.
  *
  * @author Phillip Webb
+ * @author Venkata Naga Sai Srikanth Gollapudi
  */
 public class ProjectSettingsFileTests {
 
@@ -54,6 +57,25 @@ public class ProjectSettingsFileTests {
 		assertThat(projectSettingsFile.getName()).isEqualTo("test.txt");
 		assertThat(projectSettingsFile.getContent(JavaFormatConfig.DEFAULT))
 			.hasSameContentAs(new ByteArrayInputStream("test".getBytes()));
+	}
+
+	@Test
+	void mergedWithOverlaysProperties() throws Exception {
+		File baseFile = new File(this.temp, "base.prefs");
+		writeText(baseFile, "a=1\nb=2\n");
+		File overlayFile = new File(this.temp, "overlay.prefs");
+		writeText(overlayFile, "b=3\nc=4\n");
+		ProjectSettingsFile base = ProjectSettingsFile.fromFile(baseFile);
+		ProjectSettingsFile overlay = ProjectSettingsFile.fromFile(overlayFile);
+		ProjectSettingsFile merged = base.mergedWith(overlay);
+		assertThat(merged.getName()).isEqualTo("base.prefs");
+		try (InputStream content = merged.getContent(JavaFormatConfig.DEFAULT)) {
+			Properties properties = new Properties();
+			properties.load(content);
+			assertThat(properties.getProperty("a")).isEqualTo("1");
+			assertThat(properties.getProperty("b")).isEqualTo("3");
+			assertThat(properties.getProperty("c")).isEqualTo("4");
+		}
 	}
 
 	private void writeText(File file, String s) throws FileNotFoundException {

--- a/spring-javaformat-eclipse/io.spring.javaformat.eclipse.tests/src/io/spring/javaformat/eclipse/projectsettings/ProjectSettingsFilesLocatorTests.java
+++ b/spring-javaformat-eclipse/io.spring.javaformat.eclipse.tests/src/io/spring/javaformat/eclipse/projectsettings/ProjectSettingsFilesLocatorTests.java
@@ -16,7 +16,6 @@
 
 package io.spring.javaformat.eclipse.projectsettings;
 
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -38,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link ProjectSettingsFilesLocator}.
  *
  * @author Phillip Webb
+ * @author Venkata Naga Sai Srikanth Gollapudi
  */
 public class ProjectSettingsFilesLocatorTests {
 
@@ -63,17 +63,42 @@ public class ProjectSettingsFilesLocatorTests {
 	@Test
 	void locateSettingsFilesWhenMultipleFoldersFindsInEarliest() throws Exception {
 		File folder1 = new File(this.temp, "1");
-		writeFile(folder1, "foo.prefs", "foo1");
+		writeFile(folder1, "foo.prefs", "foo=1");
 		File folder2 = new File(this.temp, "2");
-		writeFile(folder2, "foo.prefs", "foo2");
+		writeFile(folder2, "foo.prefs", "foo=2");
 		writeFile(folder2, "org.eclipse.jdt.core.prefs", "core2");
 		ProjectSettingsFiles files = new ProjectSettingsFilesLocator(folder1, folder2).locateSettingsFiles();
 		Map<String, ProjectSettingsFile> found = new LinkedHashMap<>();
 		files.iterator().forEachRemaining((f) -> found.put(f.getName(), f));
-		assertThat(found.get("foo.prefs").getContent(JavaFormatConfig.DEFAULT))
-			.hasSameContentAs(new ByteArrayInputStream("foo1".getBytes()));
-		assertThat(found.get("org.eclipse.jdt.core.prefs").getContent(JavaFormatConfig.DEFAULT))
-			.hasSameContentAs(new ByteArrayInputStream("core2".getBytes()));
+		try (InputStream content = found.get("foo.prefs").getContent(JavaFormatConfig.DEFAULT)) {
+			Properties properties = new Properties();
+			properties.load(content);
+			assertThat(properties.get("foo")).isEqualTo("1");
+		}
+	}
+
+	@Test
+	void locateSettingsFilesMergesUserFileWithDefault() throws Exception {
+		writeFile(this.temp, "org.eclipse.jdt.ui.prefs", "custome.settings=value");
+		ProjectSettingsFiles files = new ProjectSettingsFilesLocator(this.temp).locateSettingsFiles();
+		ProjectSettingsFile file = get(files, "org.eclipse.jdt.ui.prefs");
+		try (InputStream content = file.getContent(JavaFormatConfig.DEFAULT)) {
+			Properties properties = new Properties();
+			properties.load(content);
+			assertThat(properties.get("custome.settings")).isEqualTo("value");
+		}
+	}
+
+	@Test
+	void locateSettingsFilesMergesUserOverrideOnTopOfDefault() throws Exception {
+		writeFile(this.temp, "org.eclipse.jdt.ui.prefs", "org.eclipse.jdt.ui.importorder=com.example");
+		ProjectSettingsFiles files = new ProjectSettingsFilesLocator(this.temp).locateSettingsFiles();
+		ProjectSettingsFile file = get(files, "org.eclipse.jdt.ui.prefs");
+		try (InputStream content = file.getContent(JavaFormatConfig.DEFAULT)) {
+			Properties properties = new Properties();
+			properties.load(content);
+			assertThat(properties.get("org.eclipse.jdt.ui.importorder")).isEqualTo("com.example");
+		}
 	}
 
 	@Test

--- a/spring-javaformat-eclipse/io.spring.javaformat.eclipse/src/io/spring/javaformat/eclipse/projectsettings/ProjectSettingsFile.java
+++ b/spring-javaformat-eclipse/io.spring.javaformat.eclipse/src/io/spring/javaformat/eclipse/projectsettings/ProjectSettingsFile.java
@@ -18,6 +18,7 @@ package io.spring.javaformat.eclipse.projectsettings;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -25,6 +26,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
+import java.util.Properties;
 import java.util.function.BiFunction;
 
 import io.spring.javaformat.config.JavaFormatConfig;
@@ -33,6 +35,7 @@ import io.spring.javaformat.config.JavaFormatConfig;
  * A project settings file that can be copied to the project {@code .settings} folder.
  *
  * @author Phillip Webb
+ * @author Venkata Naga Sai Srikanth Gollapudi
  */
 final class ProjectSettingsFile {
 
@@ -83,6 +86,31 @@ final class ProjectSettingsFile {
 				String content = operation.apply(javaFormatConfig, writer.toString());
 				return new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
 			}
+		});
+	}
+
+	/**
+	 * Create a new {@link ProjectSettingsFile} where the content of the given overlay is
+	 * merged on top of this files's content. Properties from the overlay will override
+	 * those in this file.
+	 * @param overlay the overlay settings file to merge on top of this file
+	 * @return a new {@link ProjectSettingsFile} instance with merged content
+	 */
+	public ProjectSettingsFile mergedWith(ProjectSettingsFile overlay) {
+		return new ProjectSettingsFile(this.name, (javaFormatConfig) -> {
+			Properties properties = new Properties();
+			try (InputStream base = this.contentSupplier.getContent(javaFormatConfig)) {
+				properties.load(base);
+			}
+			try (InputStream overlayContent = overlay.getContent(javaFormatConfig)) {
+				properties.load(overlayContent);
+			}
+			ByteArrayOutputStream out = new ByteArrayOutputStream();
+			properties.store(out, null);
+			String result = out.toString(StandardCharsets.UTF_8);
+			String separator = System.getProperty("line.separator");
+			result = result.substring(result.indexOf(separator) + separator.length());
+			return new ByteArrayInputStream(result.getBytes(StandardCharsets.UTF_8));
 		});
 	}
 

--- a/spring-javaformat-eclipse/io.spring.javaformat.eclipse/src/io/spring/javaformat/eclipse/projectsettings/ProjectSettingsFilesLocator.java
+++ b/spring-javaformat-eclipse/io.spring.javaformat.eclipse/src/io/spring/javaformat/eclipse/projectsettings/ProjectSettingsFilesLocator.java
@@ -28,6 +28,7 @@ import io.spring.javaformat.config.JavaFormatConfig;
  * Locates project settings files to be applied to projects.
  *
  * @author Phillip Webb
+ * @author Venkata Naga Sai Srikanth Gollapudi
  */
 public class ProjectSettingsFilesLocator {
 
@@ -49,15 +50,24 @@ public class ProjectSettingsFilesLocator {
 
 	public ProjectSettingsFiles locateSettingsFiles() throws IOException {
 		ProjectProperties projectProperties = new ProjectProperties();
-		Map<String, ProjectSettingsFile> files = new LinkedHashMap<>();
+		Map<String, ProjectSettingsFile> userFiles = new LinkedHashMap<>();
 		for (File searchFolder : this.searchFolders) {
 			for (String sourceFolder : SOURCE_FOLDERS) {
-				add(projectProperties, files, new File(searchFolder, sourceFolder));
+				add(projectProperties, userFiles, new File(searchFolder, sourceFolder));
 			}
 		}
+		Map<String, ProjectSettingsFile> files = new LinkedHashMap<>();
 		for (String file : DEFAULT_FILES) {
-			putIfAbsent(files, getDefaultSettingsFile(file));
+			ProjectSettingsFile defaultFile = getDefaultSettingsFile(file);
+			ProjectSettingsFile userFile = userFiles.remove(defaultFile.getName());
+			if (userFile != null) {
+				files.put(defaultFile.getName(), defaultFile.mergedWith(userFile));
+			}
+			else {
+				files.put(defaultFile.getName(), defaultFile);
+			}
 		}
+		files.putAll(userFiles);
 		return new ProjectSettingsFiles(files.values(), projectProperties);
 	}
 


### PR DESCRIPTION
This PR adds 'mergedWith()' method to 'ProjectSettingsFile' that merges user-provided settings on top of the plugin's defaults. When a user file matches a default file by name, the properties are merged - with user values overriding defaults - rather than replacing the entire file

##Changes
- Added `mergedWith(ProjectSettingsFile overlay)` method to `ProjectSettingFile` that loads both base and overlay as `Properties`, merges them, and returns  a new `ProjectSettingsFile` with the combined content
- Updated `ProjectSettingsFilesLocator` to merge user settings files with matching default files instead of replacing them
- Added tests for the merge behaviour

Closes #444
<img width="1680" height="634" alt="image" src="https://github.com/user-attachments/assets/bbb1b32a-6ad0-48e0-b9b8-79fae2e30c5e" />

