### PR TITLE
Support Gradle's configuration cache

### DIFF
--- a/spring-javaformat-gradle/spring-javaformat-gradle-plugin/src/main/java/io/spring/javaformat/gradle/tasks/CheckFormat.java
+++ b/spring-javaformat-gradle/spring-javaformat-gradle-plugin/src/main/java/io/spring/javaformat/gradle/tasks/CheckFormat.java
@@ -24,6 +24,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import javax.inject.Inject;
+
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
@@ -49,7 +52,14 @@ public class CheckFormat extends FormatterTask {
 	 */
 	public static final String DESCRIPTION = "Run Spring Java formatting checks";
 
+	private final ProjectLayout projectLayout;
+
 	private File reportLocation;
+
+	@Inject
+	public CheckFormat(ProjectLayout projectLayout) {
+		this.projectLayout = projectLayout;
+	}
 
 	@TaskAction
 	public void checkFormatting() throws IOException, InterruptedException {
@@ -59,7 +69,9 @@ public class CheckFormat extends FormatterTask {
 		this.reportLocation.getParentFile().mkdirs();
 		if (!problems.isEmpty()) {
 			StringBuilder message = new StringBuilder("Formatting violations found in the following files:\n");
-			problems.stream().forEach((f) -> message.append(" * " + getProject().relativePath(f) + "\n"));
+			File projectDirectory = this.projectLayout.getProjectDirectory().getAsFile();
+			problems.stream()
+				.forEach((f) -> message.append(" * " + projectDirectory.toPath().relativize(f.toPath()) + "\n"));
 			message.append("\nRun `format` to fix.");
 			Files.write(this.reportLocation.toPath(), Collections.singletonList(message.toString()),
 					StandardOpenOption.CREATE);

--- a/spring-javaformat-gradle/spring-javaformat-gradle-plugin/src/test/java/io/spring/javaformat/gradle/CheckTaskTests.java
+++ b/spring-javaformat-gradle/spring-javaformat-gradle-plugin/src/test/java/io/spring/javaformat/gradle/CheckTaskTests.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 import java.util.stream.Stream;
@@ -125,6 +126,26 @@ public class CheckTaskTests {
 		BuildResult result = gradleBuild.buildAndFail("check");
 		assertThat(result.task(":checkFormatMain").getOutcome()).isEqualTo(TaskOutcome.FAILED);
 		result = gradleBuild.buildAndFail("check");
+		assertThat(result.task(":checkFormatMain").getOutcome()).isEqualTo(TaskOutcome.FAILED);
+	}
+
+	@Test
+	void whenUsingConfigurationCacheThenFormattingViolationsAreReported() throws IOException {
+		GradleBuild gradleBuild = this.gradleBuild.source("src/test/resources/check-bad")
+			.gradleVersion("9.1.0")
+			.debug(false);
+		BuildResult result = gradleBuild.buildAndFail("check", "--configuration-cache");
+		assertFormattingViolationWithoutConfigurationCacheProblems(result);
+		result = gradleBuild.buildAndFail("check", "--configuration-cache");
+		assertFormattingViolationWithoutConfigurationCacheProblems(result);
+		assertThat(result.getOutput()).contains("Reusing configuration cache.");
+	}
+
+	private void assertFormattingViolationWithoutConfigurationCacheProblems(BuildResult result) {
+		String sourcePath = Paths.get("src", "main", "java", "simple", "Simple.java").toString();
+		assertThat(result.getOutput()).contains("Formatting violations found in the following files:")
+			.contains(" * " + sourcePath)
+			.doesNotContain("Task.project");
 		assertThat(result.task(":checkFormatMain").getOutcome()).isEqualTo(TaskOutcome.FAILED);
 	}
 

--- a/spring-javaformat-gradle/spring-javaformat-gradle-plugin/src/test/java/io/spring/javaformat/gradle/testkit/GradleBuild.java
+++ b/spring-javaformat-gradle/spring-javaformat-gradle-plugin/src/test/java/io/spring/javaformat/gradle/testkit/GradleBuild.java
@@ -57,6 +57,8 @@ public class GradleBuild {
 
 	private String gradleVersion;
 
+	private boolean debug = true;
+
 	private GradleVersion expectDeprecationWarnings;
 
 	void before() throws IOException {
@@ -109,7 +111,7 @@ public class GradleBuild {
 		String scriptContent = new String(Files.readAllBytes(buildFile.toPath())).replace("{version}",
 				getSpringFormatVersion());
 		Files.write(buildFile.toPath(), scriptContent.getBytes(StandardCharsets.UTF_8));
-		GradleRunner gradleRunner = GradleRunner.create().withProjectDir(this.projectDir).withDebug(true);
+		GradleRunner gradleRunner = GradleRunner.create().withProjectDir(this.projectDir).withDebug(this.debug);
 		if (this.gradleVersion != null) {
 			gradleRunner.withGradleVersion(this.gradleVersion);
 		}
@@ -166,6 +168,11 @@ public class GradleBuild {
 
 	public String getGradleVersion() {
 		return this.gradleVersion;
+	}
+
+	public GradleBuild debug(boolean debug) {
+		this.debug = debug;
+		return this;
 	}
 
 	private String getSpringFormatVersion() {

--- a/spring-javaformat-gradle/spring-javaformat-gradle-plugin/src/test/resources/check-bad/build.gradle
+++ b/spring-javaformat-gradle/spring-javaformat-gradle-plugin/src/test/resources/check-bad/build.gradle
@@ -7,4 +7,6 @@ buildscript {
 apply plugin: 'java'
 apply plugin: 'io.spring.javaformat'
 
-sourceCompatibility = 1.8
+java {
+	sourceCompatibility = JavaVersion.VERSION_1_8
+}


### PR DESCRIPTION
Closes gh-461

CheckFormat currently accesses Task.project during task execution when it builds the formatting-violation message. Gradle configuration-cache validation rejects that access.

This change injects ProjectLayout into CheckFormat and uses its project directory to preserve the existing project-relative violation paths without accessing Task.project at execution time. It also adds a Gradle 9.1 TestKit regression that runs the failing check twice, verifies that the violation is still reported, and confirms that the second run reuses the configuration cache.

Tests:

- ./gradlew check --no-daemon
- ./mvnw clean install --batch-mode --no-transfer-progress